### PR TITLE
Add a copy of the license

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+LICENSE
 README.Rmd
 README.md
 README_files

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2018 Nick Golding
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
While listing the license in the DESCRIPTION is common for R packages, a more common OSS practice, generally speaking, is to have a copy of the file.