### PR TITLE
add mean, min, prod, and geom mean functions to tapply

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -63,7 +63,7 @@
 #'
 #'  #'  # miscellaneous operations
 #'  sweep(x, MARGIN, STATS, FUN = c('-', '+', '/', '*'))
-#'  tapply(X, INDEX, FUN = c("sum", "max"), ...)
+#'  tapply(X, INDEX, FUN = c("sum", "max", "mean", "min", "prod", "sqrt_n"), ...)
 #'
 #' }
 #'
@@ -78,7 +78,7 @@
 #'   and multiplication.
 #'
 #'   \code{tapply()} works on column vectors (2D greta arrays with one column),
-#'   and \code{INDEX} cannot be a greta array. Currently only two functions are
+#'   and \code{INDEX} cannot be a greta array. Currently six functions are
 #'   available, and arguments passed to \dots are ignored.
 #'
 #' @examples
@@ -725,7 +725,11 @@ tapply.greta_array <- function (X, INDEX, FUN = c("sum", "max"), ...) {
   # which function
   tf_fun <- switch(FUN,
                    sum = "tf$unsorted_segment_sum",
-                   max = "tf$unsorted_segment_max")
+                   max = "tf$unsorted_segment_max",
+                   mean = "tf$unsorted_segment_mean",
+                   min = "tf$unsorted_segment_min",
+                   prod = "tf$unsorted_segment_prod",
+                   sqrt_n = "tf$unsorted_segment_sqrt_n")
 
   # dimensions
   dimfun <- function (elem_list) {

--- a/R/functions.R
+++ b/R/functions.R
@@ -708,7 +708,9 @@ tapply.default <- function (X, INDEX, FUN = NULL, ...,
 }
 
 #' @export
-tapply.greta_array <- function (X, INDEX, FUN = c("sum", "max"), ...) {
+tapply.greta_array <- function (X, INDEX,
+                                FUN = c("sum", "max", "mean", "min", "prod", "sqrt_n"),
+                                ...) {
 
   FUN <- match.arg(FUN)
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -78,7 +78,7 @@
 #'   and multiplication.
 #'
 #'   \code{tapply()} works on column vectors (2D greta arrays with one column),
-#'   and \code{INDEX} cannot be a greta array. Currently six functions are
+#'   and \code{INDEX} cannot be a greta array. Currently five functions are
 #'   available, and arguments passed to \dots are ignored.
 #'
 #' @examples

--- a/R/functions.R
+++ b/R/functions.R
@@ -63,7 +63,7 @@
 #'
 #'  #'  # miscellaneous operations
 #'  sweep(x, MARGIN, STATS, FUN = c('-', '+', '/', '*'))
-#'  tapply(X, INDEX, FUN = c("sum", "max", "mean", "min", "prod", "sqrt_n"), ...)
+#'  tapply(X, INDEX, FUN = c("sum", "max", "mean", "min", "prod"), ...)
 #'
 #' }
 #'
@@ -709,7 +709,7 @@ tapply.default <- function (X, INDEX, FUN = NULL, ...,
 
 #' @export
 tapply.greta_array <- function (X, INDEX,
-                                FUN = c("sum", "max", "mean", "min", "prod", "sqrt_n"),
+                                FUN = c("sum", "max", "mean", "min", "prod"),
                                 ...) {
 
   FUN <- match.arg(FUN)
@@ -730,8 +730,7 @@ tapply.greta_array <- function (X, INDEX,
                    max = "tf$unsorted_segment_max",
                    mean = "tf$unsorted_segment_mean",
                    min = "tf$unsorted_segment_min",
-                   prod = "tf$unsorted_segment_prod",
-                   sqrt_n = "tf$unsorted_segment_sqrt_n")
+                   prod = "tf$unsorted_segment_prod")
 
   # dimensions
   dimfun <- function (elem_list) {

--- a/man/functions.Rd
+++ b/man/functions.Rd
@@ -20,7 +20,7 @@ TensorFlow only enables rounding to integers, so \code{round()} will
   and multiplication.
 
   \code{tapply()} works on column vectors (2D greta arrays with one column),
-  and \code{INDEX} cannot be a greta array. Currently only two functions are
+  and \code{INDEX} cannot be a greta array. Currently six functions are
   available, and arguments passed to \dots are ignored.
 }
 \section{Usage}{
@@ -81,7 +81,7 @@ TensorFlow only enables rounding to integers, so \code{round()} will
 
  #'  # miscellaneous operations
  sweep(x, MARGIN, STATS, FUN = c('-', '+', '/', '*'))
- tapply(X, INDEX, FUN = c("sum", "max"), ...)
+ tapply(X, INDEX, FUN = c("sum", "max", "mean", "min", "prod", "sqrt_n"), ...)
 
 }
 }

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -121,12 +121,6 @@ test_that('tapply works as expected', {
   check_expr(tapply(x, rep(1:5, each = 3), "mean"))
   check_expr(tapply(x, rep(1:5, each = 3), "min"))
   check_expr(tapply(x, rep(1:5, each = 3), "prod"))
-  
-  # test geometric mean
-  greta_out <- tapply(x, rep(1:5, each = 3), "sqrt_n")
-  r_out <- eval(tapply(x, rep(1:5, each = 3), function(x) exp(mean(log(x)))))
-  difference <- as.vector(abs(r_out - greta_out))
-  expect_true(all(difference < 1e-4))
 
 })
 

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -118,6 +118,15 @@ test_that('tapply works as expected', {
 
   check_expr(tapply(x, rep(1:5, each = 3), "sum"))
   check_expr(tapply(x, rep(1:5, each = 3), "max"))
+  check_expr(tapply(x, rep(1:5, each = 3), "mean"))
+  check_expr(tapply(x, rep(1:5, each = 3), "min"))
+  check_expr(tapply(x, rep(1:5, each = 3), "prod"))
+  
+  # test geometric mean
+  greta_out <- tapply(x, rep(1:5, each = 3), "sqrt_n")
+  r_out <- eval(tapply(x, rep(1:5, each = 3), function(x) exp(mean(log(x)))))
+  difference <- as.vector(abs(r_out - greta_out))
+  expect_true(all(difference < 1e-4))
 
 })
 


### PR DESCRIPTION
I wanted a prod function for tapply and realised they'd added mean/min/prod/sqrt_n tapply-style functions to tensorflow earlier this year. I've added these plus some tests (the sqrt_n test might be dodgy). (removed the sqrt_n option; it needs a bit more thinking because there's no R equivalent).