### PR TITLE
SImplify workflow to get working with RMarkdown.

### DIFF
--- a/R/greta_model_class.R
+++ b/R/greta_model_class.R
@@ -385,8 +385,6 @@ plot.greta_model <- function(x,
                                       attr_type = "graph"))
 
 
-  print(DiagrammeR::render_graph(gr), view = TRUE)
-
-  invisible(gr)
+  DiagrammeR::render_graph(gr)
 
 }


### PR DESCRIPTION
Two issues:
1) The invisible function was leading to the plot being suppressed within RMarkdown output
2) The print(..., view=TRUE) caused a browser preview to get launched when knitting docs in RMarkdown (one for each call to plot() .... very annoying)

Now, works well whether using interactively or within an RMarkdown document.  I am not aware of why these functions were used originally, so feel free to ignore this pull request.  Thanks.