### PR TITLE
Use more tfp distributions

### DIFF
--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -557,20 +557,9 @@ pareto_distribution <- R6Class(
 
     tf_distrib = function(parameters, dag) {
 
-      a <- parameters$a
-      b <- parameters$b
-
-      log_prob <- function(x)
-        log(a) + a * log(b) - (a + fl(1)) * log(x)
-
-      cdf <- function(x)
-        fl(1) - (b / x) ^ a
-
-      log_cdf <- function(x)
-        log(cdf(x))
-
-      list(log_prob = log_prob, cdf = cdf, log_cdf = log_cdf)
-
+      # a is shape, b is scale
+      tfp$distributions$Pareto(concentration = parameters$a,
+                               scale = parameters$b)
     }
 
   )

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -677,11 +677,8 @@ cauchy_distribution <- R6Class(
 
     tf_distrib = function(parameters, dag) {
 
-      loc <- parameters$location
-      s <- parameters$scale
-
-      tfp$distributions$Cauchy(loc = parameters$loc,
-                               s   = parameters$s)
+      tfp$distributions$Cauchy(loc = parameters$location,
+                               scale = parameters$scale)
     }
 
   )

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -680,17 +680,8 @@ cauchy_distribution <- R6Class(
       loc <- parameters$location
       s <- parameters$scale
 
-      log_prob <- function(x)
-        tf$negative(tf$log(fl(pi) * s * (fl(1) + tf$square( (x - loc) / s ))))
-
-      cdf <- function(x)
-        fl(1 / pi) * tf$atan( (x - loc) / s ) + fl(0.5)
-
-      log_cdf <- function(x)
-        tf$log(cdf(x))
-
-      list(log_prob = log_prob, cdf = cdf, log_cdf = log_cdf)
-
+      tfp$distributions$Cauchy(loc = parameters$loc,
+                               s   = parameters$s)
     }
 
   )

--- a/tests/testthat/test_distributions.R
+++ b/tests/testthat/test_distributions.R
@@ -704,7 +704,8 @@ test_that("distributions can be sampled from", {
   sample_distribution(beta(6.3, 5.9), lower = 0, upper = 1)
   sample_distribution(inverse_gamma(0.9, 1.3), lower = 0)
   sample_distribution(weibull(2, 1.1), lower = 0)
-  sample_distribution(pareto(2.4, 1.5), lower = 0)
+  # note change
+  sample_distribution(pareto(2.4, 1.5), lower = 1.5)
   sample_distribution(chi_squared(4.3), lower = 0)
   sample_distribution(f(24.3, 2.4), lower = 0)
 

--- a/tests/testthat/test_distributions.R
+++ b/tests/testthat/test_distributions.R
@@ -704,8 +704,7 @@ test_that("distributions can be sampled from", {
   sample_distribution(beta(6.3, 5.9), lower = 0, upper = 1)
   sample_distribution(inverse_gamma(0.9, 1.3), lower = 0)
   sample_distribution(weibull(2, 1.1), lower = 0)
-  # note change
-  sample_distribution(pareto(2.4, 1.5), lower = 1.5)
+  sample_distribution(pareto(2.4, 0.1), lower = 0.1)
   sample_distribution(chi_squared(4.3), lower = 0)
   sample_distribution(f(24.3, 2.4), lower = 0)
 


### PR DESCRIPTION
Using Cauchy was very smooth - no issues.

Pareto on the other hand required some changing of tests... The issues were that:

* the test assumed that the Pareto distribution was defined on [0, infinity] when it's defined on [b, infinity] (using greta's parameterisation) this was easy to change - though I do think this misconception is in other parts of the documentation
* The tfp Pareto is strict about testing for [b, infinity] and so the parameter values in the test meant that all the default `rnorm(n, 0, 0.1)` inits were being rejected. I have lowered the value of b to 0.1 in the test. 

Hope that makes sense!

Best, Jeffrey 

