### PR TITLE
make pb_update greater than thin to avoid zero length tensors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: greta
 Type: Package
 Title: Simple and Scalable Statistical Modelling in R
-Version: 0.3.0.9001
-Date: 2018-11-12
+Version: 0.3.0.9003
+Date: 2019-05-28
 Authors@R: c(
   person("Nick", "Golding", role = c("aut", "cre"),
          email = "nick.golding.research@gmail.com",

--- a/R/inference.R
+++ b/R/inference.R
@@ -238,6 +238,7 @@ mcmc <- function(model,
 
   # now make it finite
   pb_update <- min(pb_update, max(warmup, n_samples))
+  pb_update <- max(pb_update, thin + 1)
 
   run_samplers(samplers = samplers,
                n_samples = n_samples,

--- a/R/inference.R
+++ b/R/inference.R
@@ -31,7 +31,10 @@ greta_stash$numerical_messages <- c("is not invertible",
 #' @param n_cores the maximum number of CPU cores used by each sampler (see
 #'   details).
 #' @param verbose whether to print progress information to the console
-#' @param pb_update how regularly to update the progress bar (in iterations)
+#' @param pb_update how regularly to update the progress bar (in iterations).
+#'   If \code{pb_update} is less than or equal to \code{thin}, it will be set
+#'   to \code{thin + 1} to ensure at least one saved iteration per
+#'   \code{pb_update} iterations.
 #' @param one_by_one whether to run TensorFlow MCMC code one iteration at a
 #'   time, so that greta can handle numerical errors as 'bad' proposals (see
 #'   below).

--- a/man/inference.Rd
+++ b/man/inference.Rd
@@ -46,7 +46,10 @@ details).}
 
 \item{verbose}{whether to print progress information to the console}
 
-\item{pb_update}{how regularly to update the progress bar (in iterations)}
+\item{pb_update}{how regularly to update the progress bar (in iterations).
+If \code{pb_update} is less than or equal to \code{thin}, it will be set
+to \code{thin + 1} to ensure at least one saved iteration per
+\code{pb_update} iterations.}
 
 \item{one_by_one}{whether to run TensorFlow MCMC code one iteration at a
 time, so that greta can handle numerical errors as 'bad' proposals (see

--- a/tests/testthat/test_inference.R
+++ b/tests/testthat/test_inference.R
@@ -566,3 +566,14 @@ test_that("samplers print informatively", {
   expect_match(out, "Lmin = 1")
 
 })
+
+test_that("pb_update is greater than thin to avoid bursts with no saved iterations", {
+  
+  skip_if_not(check_tf_version())
+  set.seed(5)
+  x <- uniform(0, 1)
+  m <- model(x)
+  expect_ok(draws <- mcmc(m, n_samples = 100, warmup = 100,
+                          thin = 3, pb_update = 2))
+  
+})


### PR DESCRIPTION
I was trying to track down an error that occurs when switching from warmup to sampling. It looks a bit like this:
> Error in py_call_impl(callable, dots$args, dots$keywords): UnimplementedError: TensorArray has size zero, but element shape [?,1] is not fully defined. Currently only static shapes are supported when packing zero-size TensorArrays.

which I can recreate by setting `thin` >= `pb_update` (i.e. make burst size equal to or less than thinning rate):
`library(greta)`
`x <- normal(0, 1, dim = 1)`
`mod <- model(x)`
`draws <- mcmc(mod, n_samples = 100, warmup = 100, thin = 3, pb_update = 2)`

This PR adds a hacky fix for this. Not sure if this is exactly the original error that sent me down this rabbit-hole because I can't recreate that error and have never explicitly set `pb_update`. Does pb_update get reset anywhere other than `mcmc`?