### PR TITLE
depend on (and work with) TF 1.14.0 and TFP 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,8 @@ addons:
 before_install:
   - pip install --user numpy
   - pip install --user scipy
-  - pip install --user 'tensorflow==1.12'
-  - pip install --user 'tensorflow-probability==0.5.0'
+  - pip install --user 'tensorflow==1.14'
+  - pip install --user 'tensorflow-probability==0.7.0'
 
 after_success:
   - Rscript -e "covr::codecov()"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ License: Apache License 2.0
 URL: https://github.com/greta-dev/greta
 BugReports: https://github.com/greta-dev/greta/issues
 SystemRequirements: Python (>= 2.7.0) with header files and shared library;
-    TensorFlow (>= 1.10; https://www.tensorflow.org/);
-    Tensorflow Probability (>=0.5.0; https://www.tensorflow.org/probability/)
+    TensorFlow (v1.14; https://www.tensorflow.org/);
+    Tensorflow Probability (v0.7.0; https://www.tensorflow.org/probability/)
 Encoding: UTF-8
 LazyData: true
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: greta
 Type: Package
 Title: Simple and Scalable Statistical Modelling in R
-Version: 0.3.0.9004
-Date: 2019-05-30
+Version: 0.3.0.9005
+Date: 2019-06-02
 Authors@R: c(
   person("Nick", "Golding", role = c("aut", "cre"),
          email = "nick.golding.research@gmail.com",

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -164,8 +164,8 @@ dag_class <- R6Class(
       } else {
 
         shape <- shape(NULL, length(vals))
-        self$on_graph(free_state <- tf$placeholder(dtype = tf_float(),
-                                                   shape = shape))
+        self$on_graph(free_state <- tf$compat$v1$placeholder(dtype = tf_float(),
+                                                             shape = shape))
 
       }
 
@@ -215,19 +215,19 @@ dag_class <- R6Class(
       tfe$n_cores <- self$n_cores
       # Begin Exclude Linting
       self$tf_run(
-        config <- tf$ConfigProto(inter_op_parallelism_threads = n_cores,
+        config <- tf$compat$v1$ConfigProto(inter_op_parallelism_threads = n_cores,
                                  intra_op_parallelism_threads = n_cores))
 
       if (self$compile) {
         self$tf_run(py_set_attr(config$graph_options$optimizer_options,
                                 "global_jit_level",
-                                tf$OptimizerOptions$ON_1))
+                                tf$compat$v1$OptimizerOptions$ON_1))
       }
       # End Exclude Linting
 
       # start a session and initialise all variables
-      self$tf_run(sess <- tf$Session(config = config))
-      self$tf_run(sess$run(tf$global_variables_initializer()))
+      self$tf_run(sess <- tf$compat$v1$Session(config = config))
+      self$tf_run(sess$run(tf$compat$v1$global_variables_initializer()))
 
     },
 

--- a/R/extract_replace_combine.R
+++ b/R/extract_replace_combine.R
@@ -630,6 +630,6 @@ diag.greta_array <- function(x = 1, nrow, ncol) {
   # return the extraction op
   op("diag", x,
      dim = dims,
-     tf_operation = "tf$matrix_diag_part")
+     tf_operation = "tf$linalg$diag_part")
 
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -107,7 +107,7 @@ log.greta_array <- function(x, base = exp(1)) {
   if (has_representation(x, "log")) {
     result <- copy_representation(x, "log")
   } else {
-    result <- op("log", x, tf_operation = "tf$log",
+    result <- op("log", x, tf_operation = "tf$math$log",
                  representations = list(exp = x))
   }
   result
@@ -120,7 +120,7 @@ exp.greta_array <- function(x) {
     result <- copy_representation(x, "exp")
   } else {
     # otherwise exponentiate it, and store the log representation
-    result <- op("exp", x, tf_operation = "tf$exp",
+    result <- op("exp", x, tf_operation = "tf$math$exp",
                  representations = list(log = x))
   }
   result
@@ -128,12 +128,12 @@ exp.greta_array <- function(x) {
 
 #' @export
 log1p.greta_array <- function(x) {
-  op("log1p", x, tf_operation = "tf$log1p")
+  op("log1p", x, tf_operation = "tf$math$log1p")
 }
 
 #' @export
 expm1.greta_array <- function(x) {
-  op("expm1", x, tf_operation = "tf$expm1")
+  op("expm1", x, tf_operation = "tf$math$expm1")
 }
 
 #' @export
@@ -153,7 +153,7 @@ sign.greta_array <- function(x) {
 
 #' @export
 ceiling.greta_array <- function(x) {
-  op("ceil", x, tf_operation = "tf$ceil")
+  op("ceil", x, tf_operation = "tf$math$ceil")
 }
 
 #' @export
@@ -202,12 +202,12 @@ atan.greta_array <- function(x) {
 
 #' @export
 lgamma.greta_array <- function(x) {
-  op("lgamma", x, tf_operation = "tf$lgamma")
+  op("lgamma", x, tf_operation = "tf$math$lgamma")
 }
 
 #' @export
 digamma.greta_array <- function(x) {
-  op("digamma", x, tf_operation = "tf$digamma")
+  op("digamma", x, tf_operation = "tf$math$digamma")
 }
 
 #' @export
@@ -297,7 +297,7 @@ solve.greta_array <- function(a, b, ...) {
       result <- chol2inv(U)
     } else {
       result <- op("solve", a,
-                   tf_operation = "tf$matrix_inverse")
+                   tf_operation = "tf$linalg$inv")
     }
 
   } else {
@@ -318,7 +318,7 @@ solve.greta_array <- function(a, b, ...) {
     # ... and solve the linear equations
     result <- op("solve", a, b,
                  dim = dim(b),
-                 tf_operation = "tf$matrix_solve")
+                 tf_operation = "tf$linalg$solve")
 
   }
 
@@ -693,7 +693,7 @@ backsolve.greta_array <- function(r, x,
 
   op("backsolve", r, x,
      operation_args = list(lower = !upper.tri),
-     tf_operation = "tf$matrix_triangular_solve",
+     tf_operation = "tf$linalg$triangular_solve",
      dim = dim(x))
 
 }
@@ -734,7 +734,7 @@ forwardsolve.greta_array <- function(l, x,
 
   op("forwardsolve", l, x,
      operation_args = list(lower = !upper.tri),
-     tf_operation = "tf$matrix_triangular_solve",
+     tf_operation = "tf$linalg$triangular_solve",
      dim = dim(x))
 
 }
@@ -915,7 +915,7 @@ eigen.greta_array <- function(x, symmetric,
     # fact is a list of the two elements. But that's OK so long as the user
     # never sees it
     eig <- op("eigen", x,
-              tf_operation = "tf$self_adjoint_eig")
+              tf_operation = "tf$linalg$eigh")
 
     # get the eigenvalues and vectors as actual, sane greta arrays
     values <- op("values", eig, dim = c(nrow(eig), 1L),

--- a/R/inference_class.R
+++ b/R/inference_class.R
@@ -620,8 +620,12 @@ sampler <- R6Class(
       self$define_tf_kernel()
 
       # and the sampler info
-      dag$tf_run(sampler_burst_length <- tf$placeholder(dtype = tf$int32))
-      dag$tf_run(sampler_thin <- tf$placeholder(dtype = tf$int32))
+      dag$tf_run(
+        sampler_burst_length <- tf$compat$v1$placeholder(dtype = tf$int32)
+      )
+      dag$tf_run(
+        sampler_thin <- tf$compat$v1$placeholder(dtype = tf$int32)
+      )
 
       # define the whole draws tensor
       dag$tf_run(
@@ -763,13 +767,19 @@ hmc_sampler <- R6Class(
       tfe <- dag$tf_environment
 
       # tensors for sampler parameters
-      dag$tf_run(hmc_epsilon <- tf$placeholder(dtype = tf_float()))
-      dag$tf_run(hmc_L <- tf$placeholder(dtype = tf$int64))
+      dag$tf_run(
+        hmc_epsilon <- tf$compat$v1$placeholder(dtype = tf_float())
+      )
+      dag$tf_run(
+        hmc_L <- tf$compat$v1$placeholder(dtype = tf$int64)
+      )
 
       # need to pass in the value for this placeholder as a matrix (shape(n, 1))
       dag$tf_run(
-        hmc_diag_sd <- tf$placeholder(dtype = tf_float(),
-                                      shape = shape(dim(free_state)[[2]], 1))
+        hmc_diag_sd <- tf$compat$v1$placeholder(
+          dtype = tf_float(),
+          shape = shape(dim(free_state)[[2]], 1)
+        )
       )
 
       # but it step_sizes must be a vector (shape(n, )), so reshape it
@@ -842,13 +852,15 @@ rwmh_sampler <- R6Class(
 
       # tensors for sampler parameters
       dag$tf_run(
-        rwmh_epsilon <- tf$placeholder(dtype = tf_float())
+        rwmh_epsilon <- tf$compat$v1$placeholder(dtype = tf_float())
       )
 
       # need to pass in the value for this placeholder as a matrix (shape(n, 1))
       dag$tf_run(
-        rwmh_diag_sd <- tf$placeholder(dtype = tf_float(),
-                                       shape = shape(dim(free_state)[[2]], 1))
+        rwmh_diag_sd <- tf$compat$v1$placeholder(
+          dtype = tf_float(),
+          shape = shape(dim(free_state)[[2]], 1)
+        )
       )
 
       # but it step_sizes must be a vector (shape(n, )), so reshape it
@@ -913,7 +925,7 @@ slice_sampler <- R6Class(
 
       tfe$log_prob_fun <- dag$generate_log_prob_function()
       dag$tf_run(
-        slice_max_doublings <- tf$placeholder(dtype = tf$int32)
+        slice_max_doublings <- tf$compat$v1$placeholder(dtype = tf$int32)
       )
 
       # build the kernel
@@ -1024,7 +1036,7 @@ optimiser <- R6Class(
       dag <- self$model$dag
       tfe <- dag$tf_environment
 
-      dag$tf_sess_run(tf$global_variables_initializer())
+      dag$tf_sess_run(tf$compat$v1$global_variables_initializer())
 
       shape <- tfe$optimiser_free_state$shape
       dag$on_graph(

--- a/R/mixture.R
+++ b/R/mixture.R
@@ -152,7 +152,7 @@ mixture_distribution <- R6Class(
       weights <- parameters$weights
       weights_sum <- tf$reduce_sum(weights, 1L, keepdims = TRUE)
       weights <- weights / weights_sum
-      log_weights <- tf$log(weights)
+      log_weights <- tf$math$log(weights)
 
       log_prob <- function(x) {
 

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -34,8 +34,8 @@ data_node <- R6Class(
 
       } else {
 
-        tensor <- tf$placeholder(shape = shape,
-                                 dtype = tf_float())
+        tensor <- tf$compat$v1$placeholder(shape = shape,
+                                           dtype = tf_float())
         tfe$data_list[[tf_name]] <- value
 
       }

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -493,13 +493,14 @@ distribution_node <- R6Class(
       } else if (upper == self$bounds[2]) {
 
         # if only lower is constrained, get the log of the integral above it
-        offset <- tf$log(fl(1) - self$tf_cdf_function(fl(lower), parameters))
+        offset <- tf$math$log(fl(1) - self$tf_cdf_function(fl(lower),
+                                                           parameters))
 
       } else {
 
         # if both are constrained, get the log of the integral between them
-        offset <- tf$log(self$tf_cdf_function(fl(upper), parameters) -
-                           self$tf_cdf_function(fl(lower), parameters))
+        offset <- tf$math$log(self$tf_cdf_function(fl(upper), parameters) -
+                                self$tf_cdf_function(fl(lower), parameters))
 
       }
 

--- a/R/operators.R
+++ b/R/operators.R
@@ -106,14 +106,14 @@ NULL
 `%%.greta_array` <- function(e1, e2) {
   check_dims(e1, e2)
   op("`modulo`", e1, e2,
-     tf_operation = "tf$mod")
+     tf_operation = "tf$math$mod")
 }
 
 #' @export
 `%/%.greta_array` <- function(e1, e2) {
   check_dims(e1, e2)
   op("`integer divide`", e1, e2,
-     tf_operation = "tf$floordiv")
+     tf_operation = "tf$math$floordiv")
 }
 
 # overload %*% as an S3 generic

--- a/R/optimisers.R
+++ b/R/optimisers.R
@@ -171,7 +171,7 @@ slsqp <- function() {
 #'   optimal value
 gradient_descent <- function(learning_rate = 0.01) {
   define_tf_optimiser("gradient_descent",
-                      method = "tf$train$GradientDescentOptimizer",
+                      method = "tf$compat$v1$train$GradientDescentOptimizer",
                       parameters = list(
                         learning_rate = learning_rate
                       ))
@@ -185,7 +185,7 @@ gradient_descent <- function(learning_rate = 0.01) {
 #' @param epsilon a small constant used to condition gradient updates
 adadelta <- function(learning_rate = 0.001, rho = 1, epsilon = 1e-08) {
   define_tf_optimiser("adadelta",
-                      method = "tf$train$AdadeltaOptimizer",
+                      method = "tf$compat$v1$train$AdadeltaOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         rho = rho,
@@ -202,7 +202,7 @@ adadelta <- function(learning_rate = 0.001, rho = 1, epsilon = 1e-08) {
 adagrad <- function(learning_rate = 0.8,
                     initial_accumulator_value = 0.1) {
   define_tf_optimiser("adagrad",
-                      method = "tf$train$AdagradOptimizer",
+                      method = "tf$compat$v1$train$AdagradOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         initial_accumulator_value = initial_accumulator_value
@@ -227,7 +227,7 @@ adagrad_da <- function(learning_rate = 0.8,
                        l1_regularization_strength = 0,
                        l2_regularization_strength = 0) {
   define_tf_optimiser("adagrad_da",
-                      method = "tf$train$AdagradDAOptimizer",
+                      method = "tf$compat$v1$train$AdagradDAOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         global_step = global_step,
@@ -249,7 +249,7 @@ momentum <- function(learning_rate = 0.001,
                      momentum = 0.9,
                      use_nesterov = TRUE) {
   define_tf_optimiser("momentum",
-                      method = "tf$train$MomentumOptimizer",
+                      method = "tf$compat$v1$train$MomentumOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         momentum = momentum,
@@ -268,7 +268,7 @@ adam <- function(learning_rate = 0.1,
                  beta2 = 0.999,
                  epsilon = 1e-08) {
   define_tf_optimiser("adam",
-                      method = "tf$train$AdamOptimizer",
+                      method = "tf$compat$v1$train$AdamOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         beta1 = beta1,
@@ -288,7 +288,7 @@ ftrl <- function(learning_rate = 1,
                  l1_regularization_strength = 0,
                  l2_regularization_strength = 0) {
   define_tf_optimiser("ftrl",
-                      method = "tf$train$FtrlOptimizer",
+                      method = "tf$compat$v1$train$FtrlOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         learning_rate_power = learning_rate_power,
@@ -305,7 +305,7 @@ proximal_gradient_descent <- function(learning_rate = 0.01,
                                       l1_regularization_strength = 0,
                                       l2_regularization_strength = 0) {
   define_tf_optimiser("proximal_gradient_descent",
-                      method = "tf$train$ProximalGradientDescentOptimizer",
+                      method = "tf$compat$v1$train$ProximalGradientDescentOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         l1_regularization_strength = l1_regularization_strength,
@@ -321,7 +321,7 @@ proximal_adagrad <- function(learning_rate = 1,
                              l1_regularization_strength = 0,
                              l2_regularization_strength = 0) {
   define_tf_optimiser("proximal_adagrad",
-                      method = "tf$train$ProximalAdagradOptimizer",
+                      method = "tf$compat$v1$train$ProximalAdagradOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         initial_accumulator_value = initial_accumulator_value,
@@ -340,7 +340,7 @@ rms_prop <- function(learning_rate = 0.1,
                      momentum = 0,
                      epsilon = 1e-10) {
   define_tf_optimiser("rms_prop",
-                      method = "tf$train$RMSPropOptimizer",
+                      method = "tf$compat$v1$train$RMSPropOptimizer",
                       parameters = list(
                         learning_rate = learning_rate,
                         decay = decay,

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -236,9 +236,9 @@ binomial_distribution <- R6Class(
         lprobnot <- d$log_cdf(-probit)
 
         log_prob <- function(x) {
-          log_choose <- tf$lgamma(size + fl(1)) -
-            tf$lgamma(x + fl(1)) -
-            tf$lgamma(size - x + fl(1))
+          log_choose <- tf$math$lgamma(size + fl(1)) -
+            tf$math$lgamma(x + fl(1)) -
+            tf$math$lgamma(size - x + fl(1))
           log_choose + x * lprob + (size - x) * lprobnot
         }
 
@@ -327,7 +327,7 @@ poisson_distribution <- R6Class(
       if (self$lambda_is_log) {
         log_lambda <- parameters$lambda
       } else {
-        log_lambda <- tf$log(parameters$lambda)
+        log_lambda <- tf$math$log(parameters$lambda)
       }
 
       tfp$distributions$Poisson(log_rate = log_lambda)
@@ -721,7 +721,7 @@ logistic_distribution <- R6Class(
 
     # log_cdf in tf$cotrib$distributions has the wrong sign :/
     tf_log_cdf_function = function(x, parameters) {
-      tf$log(self$tf_cdf_function(x, parameters))
+      tf$math$log(self$tf_cdf_function(x, parameters))
     }
 
   )
@@ -752,7 +752,7 @@ f_distribution <- R6Class(
       df2 <- parameters$df2
 
       tf_lbeta <- function(a, b)
-        tf$lgamma(a) + tf$lgamma(b) - tf$lgamma(a + b)
+        tf$math$lgamma(a) + tf$math$lgamma(b) - tf$math$lgamma(a + b)
 
       log_prob <- function(x) {
         df1_x <- df1 * x
@@ -1020,7 +1020,7 @@ multivariate_normal_distribution <- R6Class(
       if (self$Sigma_is_cholesky) {
         L <- tf_transpose(parameters$Sigma)
       } else {
-        L <- tf$cholesky(parameters$Sigma)
+        L <- tf$linalg$cholesky(parameters$Sigma)
       }
 
       # add an extra dimension for the observation batch size (otherwise tfp
@@ -1138,16 +1138,16 @@ wishart_distribution <- R6Class(
 
         # get the cholesky factor of Sigma in tf orientation
         if (self$Sigma_is_cholesky) {
-          Sigma_chol <- tf$matrix_transpose(Sigma)
+          Sigma_chol <- tf$linalg$matrix_transpose(Sigma)
         } else {
-          Sigma_chol <- tf$cholesky(Sigma)
+          Sigma_chol <- tf$linalg$cholesky(Sigma)
         }
 
         # get the cholesky factor of the target in tf_orientation
         if (self$target_is_cholesky) {
-          x_chol <- tf$matrix_transpose(x)
+          x_chol <- tf$linalg$matrix_transpose(x)
         } else {
-          x_chol <- tf$cholesky(x)
+          x_chol <- tf$linalg$cholesky(x)
         }
 
         # use the density for choleskied x, with choleskied Sigma
@@ -1260,22 +1260,22 @@ lkj_correlation_distribution <- R6Class(
 
         # normalising constant
         k <- 1:n
-        a <- fl(1 - n) * tf$lgamma(eta + fl(0.5 * (n - 1)))
+        a <- fl(1 - n) * tf$math$lgamma(eta + fl(0.5 * (n - 1)))
         b <- tf_sum(fl(0.5 * k * log(pi)) +
-                      tf$lgamma(eta + fl(0.5 * (n - 1 - k))))
+                      tf$math$lgamma(eta + fl(0.5 * (n - 1 - k))))
         norm <- a + b
 
         # get the cholesky factor of the target in tf_orientation
         if (self$target_is_cholesky) {
-          x_chol <- tf$matrix_transpose(x)
+          x_chol <- tf$linalg$matrix_transpose(x)
         } else {
-          x_chol <- tf$cholesky(x)
+          x_chol <- tf$linalg$cholesky(x)
         }
 
-        diags <- tf$matrix_diag_part(x_chol)
+        diags <- tf$linalg$diag_part(x_chol)
         det <- tf$square(tf_prod(diags))
 
-        (eta - fl(1)) * tf$log(det) + norm
+        (eta - fl(1)) * tf$math$log(det) + norm
 
       }
 

--- a/R/tf_functions.R
+++ b/R/tf_functions.R
@@ -14,11 +14,11 @@ tf_as_integer <- function(x)
 
 tf_lchoose <- function(n, k) {
   one <- fl(1)
-  -tf$lgamma(one + n - k) - tf$lgamma(one + k) + tf$lgamma(one + n)
+  -tf$math$lgamma(one + n - k) - tf$math$lgamma(one + k) + tf$math$lgamma(one + n)
 }
 
 tf_lbeta <- function(a, b)
-  tf$lgamma(a) + tf$lgamma(b) - tf$lgamma(a + b)
+  tf$math$lgamma(a) + tf$math$lgamma(b) - tf$math$lgamma(a + b)
 
 # set up the tf$reduce_* functions to ignore the first dimension
 skip_dim <- function(op_name, x, drop = FALSE) {
@@ -48,11 +48,11 @@ tf_max <- function(x, drop = FALSE) {
 }
 
 tf_cumsum <- function(x) {
-  tf$cumsum(x, axis = 1L)
+  tf$math$cumsum(x, axis = 1L)
 }
 
 tf_cumprod <- function(x) {
-  tf$cumprod(x, axis = 1L)
+  tf$math$cumprod(x, axis = 1L)
 }
 
 # set the dimensions of a tensor, reshaping in the same way (column-major) as R
@@ -80,7 +80,7 @@ tf_transpose <- function(x) {
 }
 
 tf_apply <- function(x, axis, tf_fun_name) {
-  fun <- tf[[tf_fun_name]]
+  fun <- tf$math[[tf_fun_name]]
   out <- fun(x, axis = axis)
   # if we reduced we lost a dimension, make sure we have enough
   if (length(dim(out)) < 3) {
@@ -95,7 +95,7 @@ tf_tapply <- function(x, segment_ids, num_segments, op_name) {
   op_name <- paste0("unsorted_segment_", op_name)
 
   x <- tf$transpose(x, perm = c(1:2, 0L))
-  x <- tf[[op_name]](x,
+  x <- tf$math[[op_name]](x,
                      segment_ids = segment_ids,
                      num_segments = num_segments)
   x <- tf$transpose(x, perm = c(2L, 0:1))
@@ -367,19 +367,19 @@ tf_sweep <- function(x, STATS, MARGIN, FUN) {
 
 # transpose and get the right matrix, like R
 tf_chol <- function(x)
-  tf_transpose(tf$cholesky(x))
+  tf_transpose(tf$linalg$cholesky(x))
 
 tf_chol2inv <- function(U) {
   n <- dim(U)[[2]]
   eye <- fl(add_first_dim(diag(n)))
   eye <- expand_to_batch(eye, U)
-  L <- tf$matrix_transpose(U)
-  tf$cholesky_solve(L, eye)
+  L <- tf$linalg$matrix_transpose(U)
+  tf$linalg$cholesky_solve(L, eye)
 }
 
 tf_cov2cor <- function(V) {
   # sweep out variances
-  diag <- tf$matrix_diag_part(V)
+  diag <- tf$linalg$diag_part(V)
   diag <- tf$expand_dims(diag, 2L)
   Is <- tf$sqrt(fl(1) / diag)
   V <- Is * V
@@ -389,7 +389,7 @@ tf_cov2cor <- function(V) {
   n <- dim(V)[[2]]
   new_diag <- fl(t(rep(1, n)))
   new_diag <- expand_to_batch(new_diag, V)
-  tf$matrix_set_diag(V, new_diag)
+  tf$linalg$set_diag(V, new_diag)
 }
 
 tf_not <- function(x)
@@ -421,7 +421,7 @@ tf_neq <- function(x, y)
 
 # inverse link functions in tensorflow
 tf_iprobit <- function(x)
-  (tf$erf(x / fl(sqrt(2))) + fl(1)) / fl(2)
+  (tf$math$erf(x / fl(sqrt(2))) + fl(1)) / fl(2)
 
 tf_icloglog <- function(x)
   fl(1) - tf$exp(-tf$exp(x))
@@ -559,7 +559,7 @@ tf_abind <- function(..., axis) {
 }
 
 tf_only_eigenvalues <- function(x) {
-  vals <- tf$self_adjoint_eigvals(x)
+  vals <- tf$linalg$eigvalsh(x)
   dim <- tf$constant(1L, shape = list(1))
   tf$reverse(vals, dim)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -113,7 +113,7 @@ check_tf_version <- function(alert = c("none",
     } else {
 
       tf_version <- tf$`__version__`
-      tf_version_valid <- utils::compareVersion("1.10.0", tf_version) != 1
+      tf_version_valid <- utils::compareVersion("1.14.0", tf_version) != 1
 
       if (!tf_version_valid) {
         text <- paste0("you have TensorFlow version ", tf_version)
@@ -134,7 +134,7 @@ check_tf_version <- function(alert = c("none",
 
       pkg <- reticulate::import("pkg_resources")
       tfp_version <- pkg$get_distribution("tensorflow_probability")$version
-      tfp_version_valid <- utils::compareVersion("0.5.0", tfp_version) != 1
+      tfp_version_valid <- utils::compareVersion("0.7.0", tfp_version) != 1
 
       if (!tfp_version_valid) {
         text <- paste0("you have TensorFlow Probability version ", tfp_version)
@@ -146,33 +146,12 @@ check_tf_version <- function(alert = c("none",
     # if there was a problem, append the solution
     if (!tf_available | !tfp_available) {
 
-      # conda-specific installation instructions, to handle conda not having TFP
-      if (have_conda() & !have_virtualenv()) {
-
-        tf_install <- tfp_install <- ""
-
-        if (!tf_available | !tfp_available) {
-          tf_install <- '    install_tensorflow(method = "conda")\n'
-        }
-
-        if (!tfp_available) {
-          tfp_install <- paste0('   reticulate::conda_install("r-tensorflow", ',
-                                '"tensorflow-probability", pip = TRUE)\n')
-        }
-
-        install <- paste(tf_install, tfp_install, collapse = "\n")
-
-      } else {
-        # non-conda installation instructions
-        install <- sprintf("install_tensorflow(%s) ",
-                           ifelse(tfp_available,
-                                  "",
-                                  "extra_packages = \"tensorflow-probability\""))
-      }
+      install <- paste('install_tensorflow(version = "1.14.0",',
+                       'extra_packages = "tensorflow-probability==0.7.0"')
 
       # combine the problem and solution messages
-      text <- paste0("\n\ngreta requires TensorFlow (>=1.10.0) ",
-                     "and Tensorflow Probability (>=0.5.0), ",
+      text <- paste0("\n\nthis version of greta requires TensorFlow v1.14.0 ",
+                     "and Tensorflow Probability v0.7.0, ",
                      "but ", text, ". Use:\n\n",
                      install,
                      "\nto install the latest version.",

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -4,7 +4,7 @@ library(tensorflow)
 
 # set the seed and flush the graph before running tests
 if (greta:::check_tf_version())
-  tf$reset_default_graph()
+  tf$compat$v1$reset_default_graph()
 
 set.seed(2018 - 05 - 30)
 
@@ -29,8 +29,8 @@ grab <- function(x, dag = NULL, ...) {
   }
 
   dag$build_feed_dict(dots)
-  out <- tf$Session()$run(x,
-                          feed_dict = dag$tf_environment$feed_dict)
+  out <- tf$compat$v1$Session()$run(x,
+                                    feed_dict = dag$tf_environment$feed_dict)
   drop_first_dim(out)
 
 }


### PR DESCRIPTION
These are the latest releases of TF and TFP. There have been enough breaking changes in TFP, and deprecation warnings added to TF that the previous version is incompatible with them. So this fixes those, but is no longer compatible with previous versions.

Getting the correct versions lined up has been very painful, so I'm planning to peg greta to specific version of TF and TFP from now on. This should make managing installation easier too.

The installation suggestion for this version is now simpler, as TFP is on Anaconda