### PR TITLE
Fix install instructions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: greta
 Type: Package
 Title: Simple and Scalable Statistical Modelling in R
-Version: 0.3.0.9005
+Version: 0.3.0.9006
 Date: 2019-06-02
 Authors@R: c(
   person("Nick", "Golding", role = c("aut", "cre"),

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -765,7 +765,7 @@ f_distribution <- R6Class(
       cdf <- function(x) {
         df1_x <- df1 * x
         ratio <- df1_x / (df1_x + df2)
-        tf$betainc(df1 / fl(2), df2 / fl(2), ratio)
+        tf$math$betainc(df1 / fl(2), df2 / fl(2), ratio)
       }
 
       log_cdf <- function(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -147,7 +147,7 @@ check_tf_version <- function(alert = c("none",
     if (!tf_available | !tfp_available) {
 
       install <- paste('install_tensorflow(version = "1.14.0",',
-                       'extra_packages = "tensorflow-probability==0.7.0"')
+                       'extra_packages = "tensorflow-probability"')
 
       # combine the problem and solution messages
       text <- paste0("\n\nthis version of greta requires TensorFlow v1.14.0 ",


### PR DESCRIPTION
because #289 had slightly broken install instructions. these seem to work (dropping the explicit version for tfp)