### PR TITLE
[WIP] Add sampling interface

### DIFF
--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -97,7 +97,7 @@ normal_distribution <- R6Class(
     tf_distrib = function(parameters, dag) {
       tfp$distributions$Normal(loc = parameters$mean,
                                scale = parameters$sd)
-    }
+    },
 
     tf_sample = function() {
       parameters <- lapply(self$parameters, function(x) x$value())

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -99,6 +99,11 @@ normal_distribution <- R6Class(
                                scale = parameters$sd)
     }
 
+    tf_sample = function() {
+      parameters <- lapply(self$parameters, function(x) x$value())
+      self$tf_distrib(parameters, NULL)$sample(self$dim)
+    }
+
   )
 )
 


### PR DESCRIPTION
Hi Nick, 

This (single commit)^1 pull request outlines my idea for a sampling interface for distributions in greta. 

I worked a bit a while ago on a substantive pull request which added sampling to almost all distributions. Writing the code to sample the distributions was pretty easy but I was very unsure of the best (simplest, most consistent with other greta internals etc.) interface. Some reasons I was confused about this were:

- Confusion about the arguments to `tf_distrib` which I thought `tf_sample` should try to emulate
  - Why are the parameters passed, not accessed using `self$`? (I instinctively feel that `tf_sample` should have no arguments.)
  - What form are the parameters meant to take?
  - Why is `dag` passed but not used? 

- I wasn't sure what sort of internal juggling of tensorflow tenors would be required to sample a full model and how this might effect the necessary interface

The commit outlines my best idea but I am happy to receive any other ideas. 

Once the interface is decided on I would be very happy to actually go through and implement the sampling for each distribution. 

Jeffrey

 1. Or at least it would be if I knew how to edit commit messages properly 




