### PR TITLE
feature: batched calculate

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -12,9 +12,9 @@
 #'   which \code{target} is connected, or an \code{mcmc.list} object returned by
 #'   \code{\link{mcmc}}.
 #' @param precision the floating point precision to use when calculating values.
-#' @param trace_batch_size the number of posterior samples to process at a time when
-#'   \code{target} is an \code{mcmc.list} object; reduce this to reduce memory
-#'   demands
+#' @param trace_batch_size the number of posterior samples to process at a time
+#'   when \code{target} is an \code{mcmc.list} object; reduce this to reduce
+#'   memory demands
 #'
 #' @return A numeric R array with the same dimensions as \code{target}, giving
 #'   the values it would take conditioned on the fixed values given by

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -466,7 +466,9 @@ dag_class <- R6Class(
     },
 
     # return the current values of the traced nodes, as a named vector
-    trace_values = function(free_state, flatten = TRUE, trace_batch_size = Inf) {
+    trace_values = function(free_state,
+                            flatten = TRUE,
+                            trace_batch_size = Inf) {
 
       # get the number of samples to trace
       n_samples <- nrow(free_state)

--- a/R/inference.R
+++ b/R/inference.R
@@ -42,6 +42,9 @@ greta_stash$numerical_messages <- c("is not invertible",
 #'   \code{initials} objects of length \code{chains}) giving initial values for
 #'   some or all of the variables in the model. These will be used as the
 #'   starting point for sampling/optimisation.
+#' @param trace_batch_size the number of posterior samples to process at a time
+#'   when tracing the parameters of interest; reduce this to reduce memory
+#'   demands
 #'
 #' @details For \code{mcmc()} if \code{verbose = TRUE}, the progress bar shows
 #'   the number of iterations so far and the expected time to complete the phase
@@ -90,6 +93,14 @@ greta_stash$numerical_messages <- c("is not invertible",
 #'   \code{future} package, \code{n_cores} will be set so that \code{n_cores *
 #'   \link[future:nbrOfWorkers]{future::nbrOfWorkers}} is less than the number
 #'   of CPU cores.
+#'
+#'   After carrying out mcmc on all the model parameters, \code{mcmc()}
+#'   calculates the values of (i.e. traces) the parameters of interest for each
+#'   of these samples, similarly to \code{\linl[calculate]{calculate}}. Multiple
+#'   posterior samples can be traced simulataneously, though this can require
+#'   large amounts of memory for large models. As in \code{calculate}, the
+#'   argument \code{trace_batch_size} can be modified to trade-off speed against
+#'   memory usage.
 #'
 #' @return \code{mcmc}, \code{stashed_samples} & \code{extra_samples} - an
 #'   \code{mcmc.list} object that can be analysed using functions from the coda
@@ -173,7 +184,11 @@ mcmc <- function(model,
                  verbose = TRUE,
                  pb_update = 50,
                  one_by_one = FALSE,
-                 initial_values = initials()) {
+                 initial_values = initials(),
+                 trace_batch_size = 100) {
+
+  # check the trace batch size
+  trace_batch_size <- check_trace_batch_size(trace_batch_size)
 
   # find variable names to label samples
   target_greta_arrays <- model$target_greta_arrays
@@ -227,7 +242,7 @@ mcmc <- function(model,
                      sampler,
                      model)
 
-  # add chain info for printing
+  # add chain info for printing, and set trace batch size
   for (i in seq_len(n_samplers)) {
     samplers[[i]]$sampler_number <- i
     samplers[[i]]$n_samplers <- n_samplers
@@ -251,7 +266,8 @@ mcmc <- function(model,
                pb_update = pb_update,
                one_by_one = one_by_one,
                n_cores = n_cores,
-               from_scratch = TRUE)
+               from_scratch = TRUE,
+               trace_batch_size = trace_batch_size)
 
 }
 
@@ -264,7 +280,8 @@ run_samplers <- function(samplers,
                          pb_update,
                          one_by_one,
                          n_cores,
-                         from_scratch) {
+                         from_scratch,
+                         trace_batch_size) {
 
   # check the future plan is valid, and get information about it
   plan_is <- check_future_plan()
@@ -366,6 +383,7 @@ run_samplers <- function(samplers,
                         plan_is = plan_is,
                         n_cores = n_cores,
                         float_type = float_type,
+                        trace_batch_size = trace_batch_size,
                         from_scratch = from_scratch),
       seed = future_seed())
   }
@@ -492,7 +510,8 @@ extra_samples <- function(draws,
                           n_cores = NULL,
                           verbose = TRUE,
                           pb_update = 50,
-                          one_by_one = FALSE) {
+                          one_by_one = FALSE,
+                          trace_batch_size = 100) {
 
   model_info <- get_model_info(draws)
   samplers <- model_info$samplers
@@ -513,7 +532,8 @@ extra_samples <- function(draws,
                pb_update = pb_update,
                one_by_one = one_by_one,
                n_cores = n_cores,
-               from_scratch = FALSE)
+               from_scratch = FALSE,
+               trace_batch_size = trace_batch_size)
 
 }
 

--- a/R/inference.R
+++ b/R/inference.R
@@ -623,7 +623,11 @@ parse_initial_values <- function(initials, dag) {
 
   # set them in the list and flatten to a vector in the same order as tensorflow
   params[idx] <- inits_free
-  unlist_tf(params)
+  params <- unlist_tf(params)
+
+  # force them to be row vectors and return
+  params <- matrix(params, nrow = 1)
+  params
 
 }
 

--- a/R/inference_class.R
+++ b/R/inference_class.R
@@ -260,6 +260,9 @@ sampler <- R6Class(
     pb_file = NULL,
     pb_width = options()$width,
 
+    # batch sizes for tracing
+    trace_batch_size = 100,
+
     initialize = function(initial_values,
                           model,
                           parameters = list(),
@@ -289,6 +292,7 @@ sampler <- R6Class(
     run_chain = function(n_samples, thin, warmup,
                          verbose, pb_update,
                          one_by_one, plan_is, n_cores, float_type,
+                         trace_batch_size,
                          from_scratch = TRUE) {
 
       dag <- self$model$dag
@@ -385,7 +389,7 @@ sampler <- R6Class(
         # on exiting during the main sampling period (even if killed by the
         # user) trace the free state values
 
-        on.exit(self$trace_values(), add = TRUE)
+        on.exit(self$trace_values(trace_batch_size), add = TRUE)
 
         # main sampling
         if (verbose) {
@@ -468,10 +472,11 @@ sampler <- R6Class(
 
     # convert traced free state to the traced values, accounting for
     # chain dimension
-    trace_values = function() {
+    trace_values = function(trace_batch_size) {
 
       self$traced_values <- lapply(self$traced_free_state,
-                                   self$model$dag$trace_values)
+                                   self$model$dag$trace_values,
+                                   trace_batch_size = trace_batch_size)
 
     },
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1010,12 +1010,12 @@ check_positive_integer <- function(x, name = "") {
 }
 
 # batch sizes must be positive numerics, rounded off to integers
-check_trace_batch_size <- function (x) {
+check_trace_batch_size <- function(x) {
   valid <- is.numeric(x) && length(x) == 1 && x >= 1
   if (!valid) {
-    stop ("trace_batch_size must be a single numeric value ",
-          "greater than or equal to 1",
-          call. = FALSE)
+    stop("trace_batch_size must be a single numeric value ",
+         "greater than or equal to 1",
+         call. = FALSE)
   }
   x
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1009,6 +1009,17 @@ check_positive_integer <- function(x, name = "") {
 
 }
 
+# batch sizes must be positive numerics, rounded off to integers
+check_trace_batch_size <- function (x) {
+  valid <- is.numeric(x) && length(x) == 1 && x >= 1
+  if (!valid) {
+    stop ("trace_batch_size must be a single numeric value ",
+          "greater than or equal to 1",
+          call. = FALSE)
+  }
+  x
+}
+
 # get better names for the scalar elements of a greta array, for labelling mcmc
 # samples
 get_indices_text <- function(dims, name) {

--- a/tests/testthat/test_inference.R
+++ b/tests/testthat/test_inference.R
@@ -314,7 +314,14 @@ test_that("trace_batch_size works", {
   a <- normal(0, 1)
   m <- model(a)
 
-  draws <- mcmc(m, warmup = 10, n_samples = 10, verbose = FALSE, trace_batch_size = 3)
+  draws <-
+    mcmc(
+      m,
+      warmup = 10,
+      n_samples = 10,
+      verbose = FALSE,
+      trace_batch_size = 3
+    )
 
   more_draws <- extra_samples(draws, 20, verbose = FALSE, trace_batch_size = 6)
 

--- a/tests/testthat/test_inference.R
+++ b/tests/testthat/test_inference.R
@@ -305,6 +305,25 @@ test_that("extra_samples works", {
 
 })
 
+test_that("trace_batch_size works", {
+
+  skip_if_not(check_tf_version())
+  source("helpers.R")
+
+  # set up model
+  a <- normal(0, 1)
+  m <- model(a)
+
+  draws <- mcmc(m, warmup = 10, n_samples = 10, verbose = FALSE, trace_batch_size = 3)
+
+  more_draws <- extra_samples(draws, 20, verbose = FALSE, trace_batch_size = 6)
+
+  expect_true(inherits(more_draws, "mcmc.list"))
+  expect_true(coda::niter(more_draws) == 30)
+  expect_true(coda::nchain(more_draws) == 4)
+
+})
+
 test_that("stashed_samples works", {
 
   skip_if_not(check_tf_version())


### PR DESCRIPTION
adds a `trace_batch_size` argument to `calculate()`, `mcmc()`, and `extra_samples()`, which controls how many samples to process simultaneously when tracing parameter values. The default of 100 (previously it was implicitly `Inf`) doesn't slow most models down much, and seems much more stable with big operations.
