### PR TITLE
TFP distributions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,5 +91,5 @@ Suggests:
     abind,
     spelling
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: greta
 Type: Package
 Title: Simple and Scalable Statistical Modelling in R
-Version: 0.3.1.9007
-Date: 2020-01-14
+Version: 0.3.1.9008
+Date: 2020-01-25
 Authors@R: c(
   person("Nick", "Golding", role = c("aut", "cre"),
          email = "nick.golding.research@gmail.com",

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -338,13 +338,13 @@ dag_class <- R6Class(
         } else if (upper == bounds[2]) {
 
           # if only lower is constrained, get the log of the integral above it
-          offset <- tf$math$log(fl(1) - tfp_distribution$log_cdf(fl(lower)))
+          offset <- tf$math$log(fl(1) - tfp_distribution$cdf(fl(lower)))
 
         } else {
 
           # if both are constrained, get the log of the integral between them
-          offset <- tf$math$log(tfp_distribution$log_cdf(fl(upper)) -
-                                  tfp_distribution$log_cdf(fl(lower)))
+          offset <- tf$math$log(tfp_distribution$cdf(fl(upper)) -
+                                  tfp_distribution$cdf(fl(lower)))
 
         }
 

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -290,7 +290,8 @@ dag_class <- R6Class(
 
     },
 
-    # evaluate the (truncation-corrected) density of a tfp distribution on its target tensor
+    # evaluate the (truncation-corrected) density of a tfp distribution on its
+    # target tensor
     evaluate_density = function(distribution_node, target_node) {
 
       tfe <- self$tf_environment
@@ -302,7 +303,8 @@ dag_class <- R6Class(
       tf_target <- self$get_tf_object(target_node)
       tf_parameter_list <- lapply(parameter_nodes, self$get_tf_object)
 
-      # execute the distribution constructor functions to return a tfp distribution object
+      # execute the distribution constructor functions to return a tfp
+      # distribution object
       tfp_distribution <- distrib_constructor(tf_parameter_list, dag = self)
 
       self$tf_evaluate_density(tfp_distribution,

--- a/R/inference.R
+++ b/R/inference.R
@@ -96,7 +96,7 @@ greta_stash$numerical_messages <- c("is not invertible",
 #'
 #'   After carrying out mcmc on all the model parameters, \code{mcmc()}
 #'   calculates the values of (i.e. traces) the parameters of interest for each
-#'   of these samples, similarly to \code{\linl[calculate]{calculate}}. Multiple
+#'   of these samples, similarly to \code{\link{calculate}}. Multiple
 #'   posterior samples can be traced simulataneously, though this can require
 #'   large amounts of memory for large models. As in \code{calculate}, the
 #'   argument \code{trace_batch_size} can be modified to trade-off speed against

--- a/R/joint.R
+++ b/R/joint.R
@@ -104,7 +104,8 @@ joint_distribution <- R6Class(
       distribution_nodes <- self$parameters
       truncations <- lapply(distribution_nodes, member, "truncation")
       bounds <- lapply(distribution_nodes, member, "bounds")
-      distribution_parameters <- lapply(distribution_nodes, member, "parameters")
+      distribution_parameters <-
+        lapply(distribution_nodes, member, "parameters")
 
       # in this case, 'parameters' are functions to construct tfp distributions,
       # so evaluate them on their own parameters to get the tfp distributions
@@ -114,7 +115,8 @@ joint_distribution <- R6Class(
         constructor <- parameters[[i]]
 
         # get the tensors for the parameters of this component distribution
-        tf_parameter_list <- lapply(distribution_parameters[[i]], dag$get_tf_object)
+        tf_parameter_list <-
+          lapply(distribution_parameters[[i]], dag$get_tf_object)
 
         # use them to construct the tfp distribution object
         tfp_distributions[[i]] <- constructor(tf_parameter_list, dag = dag)

--- a/R/joint.R
+++ b/R/joint.R
@@ -144,11 +144,7 @@ joint_distribution <- R6Class(
 
       list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
 
-    },
-
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
-
+    }
   )
 )
 

--- a/R/joint.R
+++ b/R/joint.R
@@ -100,19 +100,42 @@ joint_distribution <- R6Class(
 
     tf_distrib = function(parameters, dag) {
 
-      densities <- parameters
-      names(densities) <- NULL
+      # get parameter nodes, truncations, and bounds of component distributions
+      distribution_nodes <- self$parameters
+      truncations <- lapply(distribution_nodes, member, "truncation")
+      bounds <- lapply(distribution_nodes, member, "bounds")
+      distribution_parameters <- lapply(distribution_nodes, member, "parameters")
+
+      # in this case, 'parameters' are functions to construct tfp distributions,
+      # so evaluate them on their own parameters to get the tfp distributions
+      tfp_distributions <- list()
+      for (i in seq_along(parameters)) {
+
+        constructor <- parameters[[i]]
+
+        # get the tensors for the parameters of this component distribution
+        tf_parameter_list <- lapply(distribution_parameters[[i]], dag$get_tf_object)
+
+        # use them to construct the tfp distribution object
+        tfp_distributions[[i]] <- constructor(tf_parameter_list, dag = dag)
+
+      }
 
       log_prob <- function(x) {
 
         # split x on the joint dimension, and loop through computing the
         # densities
         last_dim <- length(dim(x)) - 1L
-        x_vals <- tf$split(x, length(densities), axis = last_dim)
-        log_probs <- list()
-        for (i in seq_along(densities)) {
-          log_probs[[i]] <- densities[[i]](x_vals[[i]])
-        }
+        x_vals <- tf$split(x, length(tfp_distributions), axis = last_dim)
+
+        log_probs <- mapply(
+          dag$tf_evaluate_density,
+          tfp_distributions,
+          x_vals,
+          truncations,
+          bounds,
+          SIMPLIFY = FALSE
+        )
 
         # sum them elementwise
         tf$add_n(log_probs)

--- a/R/mixture.R
+++ b/R/mixture.R
@@ -160,7 +160,8 @@ mixture_distribution <- R6Class(
       distribution_nodes <- self$parameters[names(self$parameters) != "weights"]
       truncations <- lapply(distribution_nodes, member, "truncation")
       bounds <- lapply(distribution_nodes, member, "bounds")
-      distribution_parameters <- lapply(distribution_nodes, member, "parameters")
+      distribution_parameters <-
+        lapply(distribution_nodes, member, "parameters")
 
       # in this case, 'parameters' are functions to construct tfp distributions,
       # so evaluate them on their own parameters to get the tfp distributions
@@ -171,7 +172,8 @@ mixture_distribution <- R6Class(
         constructor <- constructors[[i]]
 
         # get the tensors for the parameters of this component distribution
-        tf_parameter_list <- lapply(distribution_parameters[[i]], dag$get_tf_object)
+        tf_parameter_list <-
+          lapply(distribution_parameters[[i]], dag$get_tf_object)
 
         # use them to construct the tfp distribution object
         tfp_distributions[[i]] <- constructor(tf_parameter_list, dag = dag)

--- a/R/mixture.R
+++ b/R/mixture.R
@@ -228,10 +228,7 @@ mixture_distribution <- R6Class(
 
       list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
 
-    },
-
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -385,6 +385,8 @@ distribution_node <- R6Class(
       # for all distributions, set name, store dims, and set whether discrete
       self$distribution_name <- name
       self$discrete <- discrete
+      self$multivariate <- multivariate
+      self$truncatable <- truncatable
 
       # initialize the target values of this distribution
       self$add_target(self$create_target(truncation))

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -717,11 +717,6 @@ logistic_distribution <- R6Class(
     tf_distrib = function(parameters, dag) {
       tfp$distributions$Logistic(loc = parameters$location,
                                  scale = parameters$scale)
-    },
-
-    # log_cdf in tf$cotrib$distributions has the wrong sign :/
-    tf_log_cdf_function = function(x, parameters) {
-      tf$math$log(self$tf_cdf_function(x, parameters))
     }
 
   )
@@ -1125,7 +1120,6 @@ wishart_distribution <- R6Class(
     },
 
     tf_distrib = function(parameters, dag) {
-
       # this is messy, we want to use the tfp wishart, but can't define the
       # density without expanding the dimension of x
 
@@ -1254,7 +1248,7 @@ lkj_correlation_distribution <- R6Class(
 
     tf_distrib = function(parameters, dag) {
 
-      eta <- parameters$eta
+      eta <- tf$squeeze(parameters$eta, 1L)
 
       log_prob <- function(x) {
 

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -182,11 +182,7 @@ bernoulli_distribution <- R6Class(
         tfp$distributions$Bernoulli(probs = parameters$prob)
 
       }
-    },
-
-    # no CDF for discrete distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -248,11 +244,7 @@ binomial_distribution <- R6Class(
         tfp$distributions$Binomial(total_count = parameters$size,
                                    probs = parameters$prob)
       }
-    },
-
-    # no CDF for discrete distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -291,11 +283,7 @@ beta_binomial_distribution <- R6Class(
 
       list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
 
-    },
-
-    # no CDF for discrete distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -332,11 +320,7 @@ poisson_distribution <- R6Class(
 
       tfp$distributions$Poisson(log_rate = log_lambda)
 
-    },
-
-    # no CDF for discrete distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -362,12 +346,8 @@ negative_binomial_distribution <- R6Class(
     tf_distrib = function(parameters, dag) {
       tfp$distributions$NegativeBinomial(total_count = parameters$size,
                                          probs = fl(1) - parameters$prob)
-    },
+    }
     # End Exclude Linting
-
-    # no CDF for discrete distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
 
   )
 )
@@ -405,11 +385,7 @@ hypergeometric_distribution <- R6Class(
 
       list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
 
-    },
-
-    # no CDF for discrete distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -793,7 +769,8 @@ dirichlet_distribution <- R6Class(
       # parameters
       self$bounds <- c(0, Inf)
       super$initialize("dirichlet", dim,
-                       truncation = c(0, Inf))
+                       truncation = c(0, Inf),
+                       multivariate = TRUE)
       self$add_parameter(alpha, "alpha")
 
     },
@@ -815,15 +792,10 @@ dirichlet_distribution <- R6Class(
     tf_distrib = function(parameters, dag) {
       alpha <- parameters$alpha
       tfp$distributions$Dirichlet(concentration = alpha)
-    },
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
-
 
 dirichlet_multinomial_distribution <- R6Class(
   "dirichlet_multinomial_distribution",
@@ -848,7 +820,8 @@ dirichlet_multinomial_distribution <- R6Class(
       # parameters
       super$initialize("dirichlet_multinomial",
                        dim = dim,
-                       discrete = TRUE)
+                       discrete = TRUE,
+                       multivariate = TRUE)
       self$add_parameter(size, "size", expand_scalar_to = NULL)
       self$add_parameter(alpha, "alpha")
 
@@ -861,12 +834,8 @@ dirichlet_multinomial_distribution <- R6Class(
       distrib <- tfp$distributions$DirichletMultinomial
       distrib(total_count = parameters$size,
               concentration = parameters$alpha)
-    },
+    }
     # End Exclude Linting
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
 
   )
 )
@@ -893,7 +862,8 @@ multinomial_distribution <- R6Class(
       # parameters
       super$initialize("multinomial",
                        dim = dim,
-                       discrete = TRUE)
+                       discrete = TRUE,
+                       multivariate = TRUE)
       self$add_parameter(size, "size", expand_scalar_to = NULL)
       self$add_parameter(prob, "prob")
 
@@ -907,11 +877,7 @@ multinomial_distribution <- R6Class(
 
       tfp$distributions$Multinomial(total_count = parameters$size,
                                     probs = parameters$prob)
-    },
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -932,7 +898,10 @@ categorical_distribution <- R6Class(
 
       # coerce the parameter arguments to nodes and add as parents and
       # parameters
-      super$initialize("categorical", dim = dim, discrete = TRUE)
+      super$initialize("categorical",
+                       dim = dim,
+                       discrete = TRUE,
+                       multivariate = TRUE)
       self$add_parameter(prob, "prob")
 
     },
@@ -943,11 +912,7 @@ categorical_distribution <- R6Class(
       probs <- probs / tf_sum(probs)
       tfp$distributions$Multinomial(total_count = fl(1),
                                     probs = probs)
-    },
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -996,7 +961,7 @@ multivariate_normal_distribution <- R6Class(
 
       # coerce the parameter arguments to nodes and add as parents and
       # parameters
-      super$initialize("multivariate_normal", dim)
+      super$initialize("multivariate_normal", dim, multivariate = TRUE)
 
       if (has_representation(sigma, "cholesky")) {
         sigma <- representation(sigma, "cholesky")
@@ -1027,11 +992,7 @@ multivariate_normal_distribution <- R6Class(
       tfp$distributions$MultivariateNormalTriL(loc = mu,
                                                scale_tril = l)
       # End Exclude Linting
-    },
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -1066,7 +1027,7 @@ wishart_distribution <- R6Class(
       dim <- nrow(sigma)
 
       # initialize with a cholesky factor
-      super$initialize("wishart", dim(sigma))
+      super$initialize("wishart", dim(sigma), multivariate = TRUE)
 
       # set parameters
       if (has_representation(sigma, "cholesky")) {
@@ -1155,11 +1116,7 @@ wishart_distribution <- R6Class(
 
       list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
 
-    },
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )
@@ -1197,7 +1154,7 @@ lkj_correlation_distribution <- R6Class(
       }
 
       dim <- c(dimension, dimension)
-      super$initialize("lkj_correlation", dim)
+      super$initialize("lkj_correlation", dim, multivariate = TRUE)
 
       # don't try to expand scalar eta out to match the target size
       self$add_parameter(eta, "eta", expand_scalar_to = NULL)
@@ -1277,11 +1234,7 @@ lkj_correlation_distribution <- R6Class(
 
       list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
 
-    },
-
-    # no CDF for multivariate distributions
-    tf_cdf_function = NULL,
-    tf_log_cdf_function = NULL
+    }
 
   )
 )

--- a/R/probability_distributions.R
+++ b/R/probability_distributions.R
@@ -1205,34 +1205,15 @@ lkj_correlation_distribution <- R6Class(
 
     tf_distrib = function(parameters, dag) {
 
-      eta <- tf$squeeze(parameters$eta, 1L)
+      eta <- tf$squeeze(parameters$eta, 1:2)
 
-      log_prob <- function(x) {
+      tfp$distributions$LKJ(
+        dimension = self$dim[1],
+        concentration = eta,
+        input_output_cholesky = self$target_is_cholesky
+      )
 
-        n <- self$dim[1]
-
-        # normalising constant
-        k <- 1:n
-        a <- fl(1 - n) * tf$math$lgamma(eta + fl(0.5 * (n - 1)))
-        b <- tf_sum(fl(0.5 * k * log(pi)) +
-                      tf$math$lgamma(eta + fl(0.5 * (n - 1 - k))))
-        norm <- a + b
-
-        # get the cholesky factor of the target in tf_orientation
-        if (self$target_is_cholesky) {
-          x_chol <- tf$linalg$matrix_transpose(x)
-        } else {
-          x_chol <- tf$linalg$cholesky(x)
-        }
-
-        diags <- tf$linalg$diag_part(x_chol)
-        det <- tf$square(tf_prod(diags))
-
-        (eta - fl(1)) * tf$math$log(det) + norm
-
-      }
-
-      list(log_prob = log_prob, cdf = NULL, log_cdf = NULL)
+      # input_output_cholesky argument will need to be dealt with for RNG stuff
 
     }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -160,8 +160,6 @@ check_tf_version <- function(alert = c("none",
 
 }
 
-
-
 # helper for *apply statements on R6 objects
 member <- function(x, method)
   eval(parse(text = paste0("x$", method)))

--- a/codemeta.json
+++ b/codemeta.json
@@ -393,7 +393,7 @@
   ],
   "releaseNotes": "https://github.com/dill/greta/blob/master/NEWS.md",
   "readme": "https://github.com/dill/greta/blob/master/README.md",
-  "fileSize": "479.763KB",
+  "fileSize": "480.908KB",
   "contIntegration": [
     "https://travis-ci.org/greta-dev/greta",
     "https://codecov.io/github/greta-dev/greta?branch=master"

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://greta-stats.org",
   "issueTracker": "https://github.com/greta-dev/greta/issues",
   "license": "https://spdx.org/licenses/Apache-2.0",
-  "version": "0.3.1.9007",
+  "version": "0.3.1.9008",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -393,7 +393,7 @@
   ],
   "releaseNotes": "https://github.com/dill/greta/blob/master/NEWS.md",
   "readme": "https://github.com/dill/greta/blob/master/README.md",
-  "fileSize": "480.908KB",
+  "fileSize": "481.117KB",
   "contIntegration": [
     "https://travis-ci.org/greta-dev/greta",
     "https://codecov.io/github/greta-dev/greta?branch=master"

--- a/man/calculate.Rd
+++ b/man/calculate.Rd
@@ -4,8 +4,12 @@
 \alias{calculate}
 \title{calculate greta arrays given fixed values}
 \usage{
-calculate(target, values = list(), precision = c("double", "single"),
-  trace_batch_size = 100)
+calculate(
+  target,
+  values = list(),
+  precision = c("double", "single"),
+  trace_batch_size = 100
+)
 }
 \arguments{
 \item{target}{a greta array for which to calculate the value}

--- a/man/distributions.Rd
+++ b/man/distributions.Rd
@@ -74,8 +74,7 @@ logistic(location, scale, dim = NULL, truncation = c(-Inf, Inf))
 
 f(df1, df2, dim = NULL, truncation = c(0, Inf))
 
-multivariate_normal(mean, Sigma, n_realisations = NULL,
-  dimension = NULL)
+multivariate_normal(mean, Sigma, n_realisations = NULL, dimension = NULL)
 
 wishart(df, Sigma)
 
@@ -87,8 +86,7 @@ categorical(prob, n_realisations = NULL, dimension = NULL)
 
 dirichlet(alpha, n_realisations = NULL, dimension = NULL)
 
-dirichlet_multinomial(size, alpha, n_realisations = NULL,
-  dimension = NULL)
+dirichlet_multinomial(size, alpha, n_realisations = NULL, dimension = NULL)
 }
 \arguments{
 \item{min, max}{scalar values giving optional limits to \code{uniform}

--- a/man/greta.Rd
+++ b/man/greta.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{greta}
 \alias{greta}
-\alias{greta-package}
 \title{greta: simple and scalable statistical modelling in R}
 \description{
 greta lets you write statistical models interactively in native

--- a/man/inference.Rd
+++ b/man/inference.Rd
@@ -9,22 +9,45 @@
 \alias{opt}
 \title{statistical inference on greta models}
 \usage{
-mcmc(model, sampler = hmc(), n_samples = 1000, thin = 1,
-  warmup = 1000, chains = 4, n_cores = NULL, verbose = TRUE,
-  pb_update = 50, one_by_one = FALSE, initial_values = initials(),
-  trace_batch_size = 100)
+mcmc(
+  model,
+  sampler = hmc(),
+  n_samples = 1000,
+  thin = 1,
+  warmup = 1000,
+  chains = 4,
+  n_cores = NULL,
+  verbose = TRUE,
+  pb_update = 50,
+  one_by_one = FALSE,
+  initial_values = initials(),
+  trace_batch_size = 100
+)
 
 stashed_samples()
 
-extra_samples(draws, n_samples = 1000, thin = 1, n_cores = NULL,
-  verbose = TRUE, pb_update = 50, one_by_one = FALSE,
-  trace_batch_size = 100)
+extra_samples(
+  draws,
+  n_samples = 1000,
+  thin = 1,
+  n_cores = NULL,
+  verbose = TRUE,
+  pb_update = 50,
+  one_by_one = FALSE,
+  trace_batch_size = 100
+)
 
 initials(...)
 
-opt(model, optimiser = bfgs(), max_iterations = 100,
-  tolerance = 1e-06, initial_values = initials(), adjust = TRUE,
-  hessian = FALSE)
+opt(
+  model,
+  optimiser = bfgs(),
+  max_iterations = 100,
+  tolerance = 1e-06,
+  initial_values = initials(),
+  adjust = TRUE,
+  hessian = FALSE
+)
 }
 \arguments{
 \item{model}{greta_model object}
@@ -164,7 +187,7 @@ For \code{mcmc()} if \code{verbose = TRUE}, the progress bar shows
 
   After carrying out mcmc on all the model parameters, \code{mcmc()}
   calculates the values of (i.e. traces) the parameters of interest for each
-  of these samples, similarly to \code{\linl[calculate]{calculate}}. Multiple
+  of these samples, similarly to \code{\link{calculate}}. Multiple
   posterior samples can be traced simulataneously, though this can require
   large amounts of memory for large models. As in \code{calculate}, the
   argument \code{trace_batch_size} can be modified to trade-off speed against

--- a/man/optimisers.Rd
+++ b/man/optimisers.Rd
@@ -47,27 +47,40 @@ adadelta(learning_rate = 0.001, rho = 1, epsilon = 1e-08)
 
 adagrad(learning_rate = 0.8, initial_accumulator_value = 0.1)
 
-adagrad_da(learning_rate = 0.8, global_step = 1L,
+adagrad_da(
+  learning_rate = 0.8,
+  global_step = 1L,
   initial_gradient_squared_accumulator_value = 0.1,
-  l1_regularization_strength = 0, l2_regularization_strength = 0)
+  l1_regularization_strength = 0,
+  l2_regularization_strength = 0
+)
 
 momentum(learning_rate = 0.001, momentum = 0.9, use_nesterov = TRUE)
 
-adam(learning_rate = 0.1, beta1 = 0.9, beta2 = 0.999,
-  epsilon = 1e-08)
+adam(learning_rate = 0.1, beta1 = 0.9, beta2 = 0.999, epsilon = 1e-08)
 
-ftrl(learning_rate = 1, learning_rate_power = -0.5,
-  initial_accumulator_value = 0.1, l1_regularization_strength = 0,
-  l2_regularization_strength = 0)
+ftrl(
+  learning_rate = 1,
+  learning_rate_power = -0.5,
+  initial_accumulator_value = 0.1,
+  l1_regularization_strength = 0,
+  l2_regularization_strength = 0
+)
 
-proximal_gradient_descent(learning_rate = 0.01,
-  l1_regularization_strength = 0, l2_regularization_strength = 0)
+proximal_gradient_descent(
+  learning_rate = 0.01,
+  l1_regularization_strength = 0,
+  l2_regularization_strength = 0
+)
 
-proximal_adagrad(learning_rate = 1, initial_accumulator_value = 0.1,
-  l1_regularization_strength = 0, l2_regularization_strength = 0)
+proximal_adagrad(
+  learning_rate = 1,
+  initial_accumulator_value = 0.1,
+  l1_regularization_strength = 0,
+  l2_regularization_strength = 0
+)
 
-rms_prop(learning_rate = 0.1, decay = 0.9, momentum = 0,
-  epsilon = 1e-10)
+rms_prop(learning_rate = 0.1, decay = 0.9, momentum = 0, epsilon = 1e-10)
 }
 \arguments{
 \item{maxcor}{maximum number of 'variable metric corrections' used to define

--- a/man/overloaded.Rd
+++ b/man/overloaded.Rd
@@ -52,10 +52,18 @@ eigen(x, symmetric, only.values, EISPACK)
 
 rdist(x1, x2 = NULL, compact = FALSE)
 
-abind(..., along = N, rev.along = NULL, new.names = NULL,
-  force.array = TRUE, make.names = use.anon.names,
-  use.anon.names = FALSE, use.first.dimnames = FALSE,
-  hier.names = FALSE, use.dnns = FALSE)
+abind(
+  ...,
+  along = N,
+  rev.along = NULL,
+  new.names = NULL,
+  force.array = TRUE,
+  make.names = use.anon.names,
+  use.anon.names = FALSE,
+  use.first.dimnames = FALSE,
+  hier.names = FALSE,
+  use.dnns = FALSE
+)
 
 diag(x = 1, nrow, ncol)
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -584,7 +584,12 @@ p_theta_greta <- function(niter, model, data,
 
 not_finished <- function(draws, target_samples = 5000) {
   neff <- coda::effectiveSize(draws)
-  rhats <- coda::gelman.diag(draws, multivariate = FALSE)$psrf[, 1]
+  rhats <- coda::gelman.diag(
+    x = draws,
+    multivariate = FALSE,
+    autoburnin = FALSE
+  )
+  rhats <- rhats$psrf[, 1]
   converged <- all(rhats < 1.01)
   enough_samples <- all(neff >= target_samples)
   !(converged & enough_samples)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -352,10 +352,11 @@ compare_truncated_distribution <- function(greta_fun,
   r_fun <- truncfun(which, parameters, truncation)
   r_log_density <- log(r_fun(x))
 
-  greta_log_density <- greta_density(greta_fun,
-                                     c(parameters, list(truncation = truncation)),
-                                     x = x,
-                                     dim = 1)
+  greta_log_density <- greta_density(
+    fun = greta_fun,
+    parameters = c(parameters, list(truncation = truncation)),
+    x = x,
+    dim = 1)
 
   # return absolute difference
   compare_op(r_log_density, greta_log_density, tolerance)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -352,27 +352,10 @@ compare_truncated_distribution <- function(greta_fun,
   r_fun <- truncfun(which, parameters, truncation)
   r_log_density <- log(r_fun(x))
 
-  # create greta array for truncated distribution
-  dist <- do.call(greta_fun, c(parameters,
-                               list(dim = 1, truncation = truncation)))
-
-  distrib_node <- get_node(dist)$distribution
-
-  # set data as the target
-  x_ <- as_data(x)
-  distribution(x_) <- dist
-
-  # create dag and define the density
-  dag <- greta:::dag_class$new(list(x_))
-  tfe <- dag$tf_environment
-
-  distrib_node$define_tf(dag)
-
-  # get the log density as a vector
-  target <- get(dag$tf_name(get_node(x_)), envir = tfe)
-  density <- get(dag$tf_name(distrib_node), envir = tfe)
-  result <- density(target)
-  greta_log_density <- as.vector(grab(result, dag))
+  greta_log_density <- greta_density(greta_fun,
+                                     c(parameters, list(truncation = truncation)),
+                                     x = x,
+                                     dim = 1)
 
   # return absolute difference
   compare_op(r_log_density, greta_log_density, tolerance)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -146,9 +146,7 @@ greta_density <- function(fun, parameters, x,
   distrib_node$define_tf(dag)
 
   # get the log density as a vector
-  target <- get(dag$tf_name(get_node(x_)), envir = tfe)
-  density <- get(dag$tf_name(distrib_node), envir = tfe)
-  result <- density(target)
+  result <- dag$evaluate_density(distrib_node, get_node(x_))
   as.vector(grab(result, dag))
 
 }

--- a/tests/testthat/test_distributions.R
+++ b/tests/testthat/test_distributions.R
@@ -336,33 +336,20 @@ test_that("lkj distribution has correct density", {
   eta <- 3
 
   # normalising component of lkj (depends only on eta and dimension)
-  lkj_normalising <- function(eta, n) {
-    if (eta == 1) {
-      result <- sum(lgamma(2 * 1:((n - 1) / 2 + 1)))
-      if (n %% 2 == 1) {
-        add <- (0.25 * (n ^ 2 - 1) * log(pi)
-                - 0.25 * (n - 1) ^ 2 * log(2)
-                - (n - 1) * lgamma((n + 1) / 2))
-      } else {
-        add <- (0.25 * n * (n - 2) * log(pi)
-                + 0.25 * (3 * n ^ 2 - 4 * n) * log(2)
-                + n * lgamma(n / 2) - (n - 1) * lgamma(n))
-      }
-      result <- result + add
-    } else {
-      result <- (1 - n) * lgamma(eta + 0.5 * (n - 1))
-      k <- 1:n
-      result <- result + sum(0.5 * k * log(pi)
-                             + lgamma(eta + 0.5 * (n - 1 - k)))
+  lkj_log_normalising <- function(eta, n) {
+    log_pi <- log(pi)
+    ans <- 0
+    for (k in 1:(n - 1)) {
+      ans <- ans + log_pi * (k / 2)
+      ans <- ans + lgamma(eta + (n - 1 - k) / 2)
+      ans <- ans - lgamma(eta + (n - 1) / 2)
     }
-
-    result
-
+    ans
   }
 
   # lkj density
   dlkj_correlation <- function(x, eta, log = FALSE, dimension = NULL) {
-    res <- lkj_normalising(eta, ncol(x)) + (eta - 1) * log(det(x))
+    res <- (eta - 1) * log(det(x)) - lkj_log_normalising(eta, ncol(x))
     if (!log)
       res <- exp(res)
     res


### PR DESCRIPTION
mild refactor to make DAGs pass around TFP distribution objects, rather than log probability functions

Implements point 2.1 in #322 

This should enable greta.hmm to act on joint distributions, and will make it easier to simulate data, using the TFP distributions' RNG functionality