### PR TITLE
Move abind from SUGGESTS to IMPORTS. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,7 +74,8 @@ Imports:
     progress (>= 1.2.0),
     future,
     coda,
-    methods
+    methods,
+    abind
 Suggests:
     knitr,
     rmarkdown,
@@ -91,7 +92,6 @@ Suggests:
     tidyverse,
     fields,
     MASS,
-    abind,
     spelling
 VignetteBuilder: knitr
 RoxygenNote: 7.0.2


### PR DESCRIPTION
 mcmc() function, i.e. core greta functionality, does not work without abind package installed because creation of hmc_sampler class relies on abind.  To avoid users getting an error message when first running the mcmc() function, I recommend making abind a package that is automatically installed when greta is installed.