### PR TITLE
remove uses of LINPACK since it has been defunct since R 3.1. Closes …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ SystemRequirements: Python (>= 2.7.0) with header files and shared library;
 Encoding: UTF-8
 LazyData: true
 Depends:
-    R (>= 3.0)
+    R (>= 3.1.0)
 Collate:
     'package.R'
     'utils.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# greta (development version)
+# greta 0.3.1.9000 (development version)
 
 ## Fixes:
 
@@ -11,6 +11,10 @@
 * greta now provides R versions of all of R's primitive functions (I think), to prevent them from silently not executing (#317).
 
 ## API changes:
+
+* Now depends on R >= 3.1.0 ([#386](https://github.com/greta-dev/greta/issues/386))
+
+* `chol2inv.greta_array()` now warns user about LINPACK argument being ignored, and also reminds user it has been deprecated since R 3.1
 
 * `calculate()` now accepts multiple greta arrays for which to calculate values, via the `...` argument. As a consequence any other arguments must now be named.
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -413,15 +413,11 @@ chol2inv <- function(x, size = NCOL(x), LINPACK = FALSE) {
 
 #' @export
 chol2inv.default <- function(x, size = NCOL(x), LINPACK = FALSE) {
-  base::chol2inv(x = x, size = size, LINPACK = LINPACK)
+  base::chol2inv(x = x, size = size)
 }
 
 #' @export
 chol2inv.greta_array <- function(x, size = NCOL(x), LINPACK = FALSE) {
-
-  if (!identical(LINPACK, FALSE)) {
-    warning("'LINPACK' is ignored for greta arrays")
-  }
 
   if (!identical(size, NCOL(x))) {
     warning("'size' is ignored for greta arrays")

--- a/R/functions.R
+++ b/R/functions.R
@@ -419,6 +419,10 @@ chol2inv.default <- function(x, size = NCOL(x), LINPACK = FALSE) {
 #' @export
 chol2inv.greta_array <- function(x, size = NCOL(x), LINPACK = FALSE) {
 
+  if (!identical(LINPACK, FALSE)) {
+    warning("The 'LINPACK' argument is ignored for greta arrays, and has also been defunct since R 3.1.0")
+  }
+
   if (!identical(size, NCOL(x))) {
     warning("'size' is ignored for greta arrays")
   }

--- a/R/overloaded.R
+++ b/R/overloaded.R
@@ -14,9 +14,13 @@
 #'    arguments as in original documentation
 #'
 #' @details
-#'   Note that, as in R, the LINPACK argument is defunct and silently ignored.
+#'   Note that, since R 3.1, the LINPACK argument is defunct and silently ignored.
 #'   The argument is only included for compatibility with the base functions
 #'   that call it.
+#'
+#'   To find the original help file for these overloaded functions, search
+#'   using the namespaced function. E.g., `?stats::cov2cor()`,
+#'   `?base::identity()`.
 #'
 NULL
 # nolint end

--- a/R/overloaded.R
+++ b/R/overloaded.R
@@ -13,5 +13,10 @@
 #'   x,y,size,LINPACK,V,na.rm,dims,MARGIN,STATS,FUN,check.margin,\dots,r,k,upper.tri,transpose,l,X,INDEX,symmetric,only.values,EISPACK,x1,x2,compact,along,rev.along,new.names,force.array,make.names,use.anon.names,use.first.dimnames,hier.names,use.dnns,nrow,ncol
 #'    arguments as in original documentation
 #'
+#' @details
+#'   Note that, as in R, the LINPACK argument is defunct and silently ignored.
+#'   The argument is only included for compatibility with the base functions
+#'   that call it.
+#'
 NULL
 # nolint end

--- a/R/overloaded.R
+++ b/R/overloaded.R
@@ -18,9 +18,8 @@
 #'   The argument is only included for compatibility with the base functions
 #'   that call it.
 #'
-#'   To find the original help file for these overloaded functions, search
-#'   using the namespaced function. E.g., `?stats::cov2cor()`,
-#'   `?base::identity()`.
+#'   To find the original help file for these overloaded functions, search for
+#'   the function, e.g., `?cov2cor` and select the non-greta function.
 #'
 NULL
 # nolint end

--- a/man/overloaded.Rd
+++ b/man/overloaded.Rd
@@ -82,7 +82,6 @@ Note that, since R 3.1, the LINPACK argument is defunct and silently ignored.
 The argument is only included for compatibility with the base functions
 that call it.
 
-To find the original help file for these overloaded functions, search
-using the namespaced function. E.g., \code{?stats::cov2cor()},
-\code{?base::identity()}.
+To find the original help file for these overloaded functions, search for
+the function, e.g., \code{?cov2cor} and select the non-greta function.
 }

--- a/man/overloaded.Rd
+++ b/man/overloaded.Rd
@@ -78,7 +78,11 @@ overloaded here. This should not affect normal use of these functions, but
 they need to be documented to satisfy CRAN's check.
 }
 \details{
-Note that, as in R, the LINPACK argument is defunct and silently ignored.
+Note that, since R 3.1, the LINPACK argument is defunct and silently ignored.
 The argument is only included for compatibility with the base functions
 that call it.
+
+To find the original help file for these overloaded functions, search
+using the namespaced function. E.g., \code{?stats::cov2cor()},
+\code{?base::identity()}.
 }

--- a/man/overloaded.Rd
+++ b/man/overloaded.Rd
@@ -77,3 +77,8 @@ functions and operators are not associated with a class system, so they are
 overloaded here. This should not affect normal use of these functions, but
 they need to be documented to satisfy CRAN's check.
 }
+\details{
+Note that, as in R, the LINPACK argument is defunct and silently ignored.
+The argument is only included for compatibility with the base functions
+that call it.
+}

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -500,9 +500,6 @@ test_that("ignored options are errored/warned about", {
   expect_warning(chol(x, pivot = TRUE),
                  "ignored for greta arrays")
 
-  expect_warning(chol2inv(x, LINPACK = TRUE),
-                 "ignored for greta arrays")
-
   expect_warning(chol2inv(x, size = 1),
                  "ignored for greta arrays")
 

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -500,6 +500,9 @@ test_that("ignored options are errored/warned about", {
   expect_warning(chol(x, pivot = TRUE),
                  "ignored for greta arrays")
 
+  expect_warning(chol2inv(x, LINPACK = TRUE),
+                 "ignored for greta arrays")
+
   expect_warning(chol2inv(x, size = 1),
                  "ignored for greta arrays")
 


### PR DESCRIPTION
…#386