### PR TITLE
use unclass instead of "strip_unknown_class"

### DIFF
--- a/R/unknowns_class.R
+++ b/R/unknowns_class.R
@@ -16,17 +16,10 @@ as.unknowns.matrix <- function(x) { # nolint
   as.unknowns.array(x)
 }
 
-strip_unknown_class <- function(x) {
-  classes <- class(x)
-  classes <- classes[classes != "unknowns"]
-  class(x) <- classes
-  x
-}
-
 #' @export
 print.unknowns <- function(x, ...) {
   # remove 'unknown' class attribute
-  x <- strip_unknown_class(x)
+  x <- unclass(x)
 
   # set NA values to ? for printing
   x[is.na(x)] <- " ?"
@@ -43,13 +36,12 @@ unknowns <- function(dims = c(1, 1), data = as.numeric(NA)) {
 
 # set dims like on a matrix/array
 `dim<-.unknowns` <- function(x, value) { # nolint
-  x <- strip_unknown_class(x)
+  x <- unclass(x)
   dim(x) <- value
   as.unknowns(x)
 }
 
 unknowns_module <- module(
   unknowns,
-  as.unknowns,
-  strip_unknown_class
+  as.unknowns
 )

--- a/R/utils.R
+++ b/R/utils.R
@@ -915,7 +915,7 @@ check_values_list <- function(values, env) {
 
   # coerce value to have the correct dimensions
   assign_dim <- function(value, greta_array) {
-    array <- strip_unknown_class(get_node(greta_array)$value())
+    array <- unclass(get_node(greta_array)$value())
     if (length(array) != length(value)) {
       stop("a provided value has different number of elements",
         " than the greta array",


### PR DESCRIPTION
resolves #410

``` r
library(greta)
#> 
#> Attaching package: 'greta'
#> The following objects are masked from 'package:stats':
#> 
#>     binomial, cov2cor, poisson
#> The following objects are masked from 'package:base':
#> 
#>     %*%, apply, backsolve, beta, chol2inv, colMeans, colSums, diag,
#>     eigen, forwardsolve, gamma, identity, rowMeans, rowSums, sweep,
#>     tapply
q_n <- normal(0, 1)
q_n
#> greta array (variable following a normal distribution)
#> 
#>      [,1]
#> [1,]  ?
```

<sup>Created on 2021-05-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 4.0.5 (2021-03-31)
#>  os       macOS Big Sur 10.16         
#>  system   x86_64, darwin17.0          
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_AU.UTF-8                 
#>  ctype    en_AU.UTF-8                 
#>  tz       Australia/Perth             
#>  date     2021-05-06                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date       lib source            
#>  backports     1.2.1      2020-12-09 [1] standard (@1.2.1) 
#>  base64enc     0.1-3      2015-07-28 [1] standard (@0.1-3) 
#>  cli           2.4.0      2021-04-05 [1] CRAN (R 4.0.2)    
#>  coda          0.19-4     2020-09-30 [1] CRAN (R 4.0.2)    
#>  codetools     0.2-18     2020-11-04 [1] CRAN (R 4.0.5)    
#>  crayon        1.4.1      2021-02-08 [1] CRAN (R 4.0.2)    
#>  digest        0.6.27     2020-10-24 [1] standard (@0.6.27)
#>  ellipsis      0.3.1      2020-05-15 [1] standard (@0.3.1) 
#>  evaluate      0.14       2019-05-28 [1] standard (@0.14)  
#>  fansi         0.4.2      2021-01-15 [1] CRAN (R 4.0.2)    
#>  fs            1.5.0      2020-07-31 [1] standard (@1.5.0) 
#>  future        1.21.0     2020-12-10 [1] CRAN (R 4.0.2)    
#>  globals       0.14.0     2020-11-22 [1] CRAN (R 4.0.2)    
#>  glue          1.4.2      2020-08-27 [1] standard (@1.4.2) 
#>  greta       * 0.3.1.9012 2021-05-06 [1] local             
#>  highr         0.8        2019-03-20 [1] standard (@0.8)   
#>  hms           1.0.0      2021-01-13 [1] CRAN (R 4.0.2)    
#>  htmltools     0.5.1.1    2021-01-22 [1] CRAN (R 4.0.2)    
#>  jsonlite      1.7.2      2020-12-09 [1] standard (@1.7.2) 
#>  knitr         1.31       2021-01-27 [1] CRAN (R 4.0.2)    
#>  lattice       0.20-41    2020-04-02 [1] CRAN (R 4.0.5)    
#>  lifecycle     1.0.0      2021-02-15 [1] CRAN (R 4.0.2)    
#>  listenv       0.8.0      2019-12-05 [1] CRAN (R 4.0.2)    
#>  magrittr      2.0.1      2020-11-17 [1] standard (@2.0.1) 
#>  Matrix        1.3-2      2021-01-06 [1] CRAN (R 4.0.5)    
#>  parallelly    1.24.0     2021-03-14 [1] CRAN (R 4.0.2)    
#>  pillar        1.6.0      2021-04-13 [1] CRAN (R 4.0.2)    
#>  pkgconfig     2.0.3      2019-09-22 [1] standard (@2.0.3) 
#>  prettyunits   1.1.1      2020-01-24 [1] standard (@1.1.1) 
#>  progress      1.2.2      2019-05-16 [1] CRAN (R 4.0.2)    
#>  purrr         0.3.4      2020-04-17 [1] standard (@0.3.4) 
#>  R6            2.5.0      2020-10-28 [1] standard (@2.5.0) 
#>  Rcpp          1.0.6      2021-01-15 [1] CRAN (R 4.0.2)    
#>  reprex        2.0.0      2021-04-02 [1] CRAN (R 4.0.2)    
#>  reticulate    1.19       2021-04-21 [1] CRAN (R 4.0.2)    
#>  rlang         0.4.10     2020-12-30 [1] CRAN (R 4.0.2)    
#>  rmarkdown     2.7        2021-02-19 [1] CRAN (R 4.0.2)    
#>  sessioninfo   1.1.1      2018-11-05 [1] standard (@1.1.1) 
#>  stringi       1.5.3      2020-09-09 [1] standard (@1.5.3) 
#>  stringr       1.4.0      2019-02-10 [1] standard (@1.4.0) 
#>  styler        1.4.1      2021-03-30 [1] CRAN (R 4.0.2)    
#>  tensorflow    2.4.0      2021-03-23 [1] CRAN (R 4.0.3)    
#>  tfruns        1.5.0      2021-02-26 [1] CRAN (R 4.0.2)    
#>  tibble        3.1.1      2021-04-18 [1] CRAN (R 4.0.3)    
#>  utf8          1.2.1      2021-03-12 [1] CRAN (R 4.0.2)    
#>  vctrs         0.3.7      2021-03-29 [1] CRAN (R 4.0.3)    
#>  whisker       0.4        2019-08-28 [1] standard (@0.4)   
#>  withr         2.4.2      2021-04-18 [1] CRAN (R 4.0.3)    
#>  xfun          0.22       2021-03-11 [1] CRAN (R 4.0.2)    
#>  yaml          2.2.1      2020-02-01 [1] standard (@2.2.1) 
#> 
#> [1] /Library/Frameworks/R.framework/Versions/4.0/Resources/library
```

</details>