### PR TITLE
Uses `Sys.unsetenv("RETICULATE_PYTHON")` in `.onload` on package star…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
 
 * greta now provides R versions of all of R's primitive functions (I think), to prevent them from silently not executing (#317).
 
+* Uses `Sys.unsetenv("RETICULATE_PYTHON")` in `.onload` on package startup, 
+  to prevent an issue introduced with the latest version of RStudio where they
+  do not find the current version of RStudio. See [#444](https://github.com/greta-dev/greta/issues/444) for more details.
+
 ## API changes:
 
 * Now depends on R >= 3.1.0 ([#386](https://github.com/greta-dev/greta/issues/386))

--- a/R/package.R
+++ b/R/package.R
@@ -44,6 +44,10 @@ tfp <- reticulate::import("tensorflow_probability", delay_load = TRUE)
 # crate the node list object whenever the package is loaded
 .onLoad <- function(libname, pkgname) { # nolint
 
+  # unset reticulate python environment, for more details, see:
+  # https://github.com/greta-dev/greta/issues/444
+  Sys.unsetenv("RETICULATE_PYTHON")
+
   if (have_greta_conda_env()) {
     use_greta_conda_env()
   }


### PR DESCRIPTION
…tup,

  to prevent an issue introduced with the latest version of RStudio where they
  do not find the current version of RStudio. See #444. Resolves #444