### PR TITLE
Update and fix R CMD Check workflow 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
             mvtnorm=?ignore-before-r=3.6.0
 
       - name: install mvtnorm and mcmcpack for R < 3.6
-        if: ${{ runner.os == "Linux" && env.UPGRADE_PKGS }}
+        if: ${{ runner.os == 'Linux' && env.UPGRADE_PKGS }}
         run: |
           Sys.getenv("UPGRADE_PKGS")
           if (Sys.getenv("UPGRADE_PKGS")) {

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
             mvtnorm=?ignore-before-r=3.6.0
 
       - name: install mvtnorm and mcmcpack for R < 3.6
-        if: ${{ runner.os == 'Linux' && env.UPGRADE_PKGS }}
+        if: ${{ runner.os == 'Linux' && (matrix.config.r == '3.4' || matrix.config.r == '3.5') }}
         run: |
           Sys.getenv("UPGRADE_PKGS")
           if (Sys.getenv("UPGRADE_PKGS")) {

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
             mvtnorm=?ignore-before-r=3.6.0
 
       - name: install mvtnorm and mcmcpack for R < 3.6
-        if: runner.os == "Linux" && env.UPGRADE_PKGS
+        if: ${{ runner.os == "Linux" && env.UPGRADE_PKGS }}
         run: |
           Sys.getenv("UPGRADE_PKGS")
           if (Sys.getenv("UPGRADE_PKGS")) {

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,9 +59,9 @@ jobs:
             local::.
             any::keras
             any::rcmdcheck
-            any::MCMCpack=?ignore-before-r=3.6.0
-            any::quantreg=?ignore-before-r=3.6.0
-            any::mvtnorm=?ignore-before-r=3.6.0
+            MCMCpack=?ignore-before-r=3.6.0
+            quantreg=?ignore-before-r=3.6.0
+            mvtnorm=?ignore-before-r=3.6.0
 
       - name: install mvtnorm and mcmcpack for R < 3.6
         if: runner.os == "Linux" && ${{ env.UPGRADE_PKGS }}
@@ -80,23 +80,6 @@ jobs:
             packageVersion("MCMCpack")
           }
         shell: Rscript {0}
-
-      # - name: specially install pkgs for windows
-      #   if: runner.os == 'Windows'
-      #   run: |
-      #     install.packages("MCMCpack", type = "binary")
-      #     install.packages("igraph", type = "binary")
-      #     library(igraph)
-      #     packageVersion("igraph")
-      #     install.packages("maps", type = "binary")
-      #     library(maps)
-      #     packageVersion("maps")
-      #     install.packages("fields", type = "binary")
-      #     library(fields)
-      #     packageVersion("fields")
-      #     install.packages("DiagrammeR")
-      #     packageVersion("DiagrammeR")
-      #   shell: Rscript {0}
 
       - name: Install Miniconda
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,8 +64,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ env.cache-version }}-${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-r-${{ matrix.config.r }}-
+          key: ${{ env.cache-version }}-${{ runner.os }}-1-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-1-${{ matrix.config.r }}-
 
       - name: Install system dependencies on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
             mvtnorm=?ignore-before-r=3.6.0
 
       - name: install mvtnorm and mcmcpack for R < 3.6
-        if: runner.os == "Linux" && ${{ env.UPGRADE_PKGS }}
+        if: runner.os == "Linux" && env.UPGRADE_PKGS
         run: |
           Sys.getenv("UPGRADE_PKGS")
           if (Sys.getenv("UPGRADE_PKGS")) {

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,23 +56,30 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
+            local::.
+            any::keras
             any::rcmdcheck
+            any::MCMCpack=?ignore-before-r=3.6.0
+            any::quantreg=?ignore-before-r=3.6.0
+            any::mvtnorm=?ignore-before-r=3.6.0
 
-      # - name: install mvtnorm and mcmcpack for R < 3.6
-      #   if: runner.os == "Linux" && ${{ env.UPGRADE_PKGS }}
-      #   run: |
-      #     Sys.getenv("UPGRADE_PKGS")
-      #     if (Sys.getenv("UPGRADE_PKGS")) {
-      #       install.packages("remotes")
-      #       install.packages("versions")
-      #       versions::install.dates("quantreg", "2017-03-06")
-      #       versions::install.dates("mvtnorm", "2017-03-06")
-      #       versions::install.dates("MCMCpack", "2017-03-06")
-      #       packageVersion("quantreg")
-      #       packageVersion("mvtnorm")
-      #       packageVersion("MCMCpack")
-      #     }
-      #   shell: Rscript {0}
+      - name: install mvtnorm and mcmcpack for R < 3.6
+        if: runner.os == "Linux" && ${{ env.UPGRADE_PKGS }}
+        run: |
+          Sys.getenv("UPGRADE_PKGS")
+          if (Sys.getenv("UPGRADE_PKGS")) {
+            pak::repo_add("MRAN@2017-03-06")
+            pak::pak(c("quantreg", "mvtnorm", "MCMCpack"))
+            # install.packages("remotes")
+            # install.packages("versions")
+            # versions::install.dates("quantreg", "2017-03-06")
+            # versions::install.dates("mvtnorm", "2017-03-06")
+            # versions::install.dates("MCMCpack", "2017-03-06")
+            packageVersion("quantreg")
+            packageVersion("mvtnorm")
+            packageVersion("MCMCpack")
+          }
+        shell: Rscript {0}
 
       # - name: specially install pkgs for windows
       #   if: runner.os == 'Windows'
@@ -93,7 +100,6 @@ jobs:
 
       - name: Install Miniconda
         run: |
-          install.packages(c("remotes", "keras"))
           reticulate::install_miniconda()
         shell: Rscript {0}
 
@@ -106,9 +112,13 @@ jobs:
 # installing into? Can we call our own greta install functions here?
       - name: Install TensorFlow
         run: |
+          cat("::group::Create Environment", sep = "\n")
           reticulate::conda_create('r-reticulate', packages = c('python==3.7'))
-          remotes::install_local()
-          keras::install_keras(tensorflow = Sys.getenv('TF_VERSION'), extra_packages = c('IPython', 'requests', 'certifi', 'urllib3', 'tensorflow-probability==0.7.0', 'numpy==1.16.4'))
+          cat("::endgroup::", sep = "\n")
+          cat("::group::Install Tensorflow", sep = "\n")
+          keras::install_keras(tensorflow = Sys.getenv('TF_VERSION'), 
+              extra_packages = c('IPython', 'requests', 'certifi', 'urllib3', 'tensorflow-probability==0.7.0', 'numpy==1.16.4'))
+          cat("::endgroup::", sep = "\n")
         shell: Rscript {0}
 
       - name: Python + TF details

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,74 +45,51 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         id: install-r
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Query dependencies
-        run: |
-          install.packages("remotes")
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ env.cache-version }}-${{ runner.os }}-1-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-1-${{ matrix.config.r }}-
+          extra-packages: |
+            any::rcmdcheck
 
-      - name: Install system dependencies on Linux
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "18.04"))')
+      # - name: install mvtnorm and mcmcpack for R < 3.6
+      #   if: runner.os == "Linux" && ${{ env.UPGRADE_PKGS }}
+      #   run: |
+      #     Sys.getenv("UPGRADE_PKGS")
+      #     if (Sys.getenv("UPGRADE_PKGS")) {
+      #       install.packages("remotes")
+      #       install.packages("versions")
+      #       versions::install.dates("quantreg", "2017-03-06")
+      #       versions::install.dates("mvtnorm", "2017-03-06")
+      #       versions::install.dates("MCMCpack", "2017-03-06")
+      #       packageVersion("quantreg")
+      #       packageVersion("mvtnorm")
+      #       packageVersion("MCMCpack")
+      #     }
+      #   shell: Rscript {0}
 
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: install mvtnorm and mcmcpack for R < 3.6
-        if: runner.os == "Linux" && ${{ env.UPGRADE_PKGS }}
-        run: |
-          Sys.getenv("UPGRADE_PKGS")
-          if (Sys.getenv("UPGRADE_PKGS")) {
-            install.packages("remotes")
-            install.packages("versions")
-            versions::install.dates("quantreg", "2017-03-06")
-            versions::install.dates("mvtnorm", "2017-03-06")
-            versions::install.dates("MCMCpack", "2017-03-06")
-            packageVersion("quantreg")
-            packageVersion("mvtnorm")
-            packageVersion("MCMCpack")
-          }
-        shell: Rscript {0}
-
-      - name: specially install pkgs for windows
-        if: runner.os == 'Windows'
-        run: |
-          install.packages("MCMCpack", type = "binary")
-          install.packages("igraph", type = "binary")
-          library(igraph)
-          packageVersion("igraph")
-          install.packages("maps", type = "binary")
-          library(maps)
-          packageVersion("maps")
-          install.packages("fields", type = "binary")
-          library(fields)
-          packageVersion("fields")
-          install.packages("DiagrammeR")
-          packageVersion("DiagrammeR")
-        shell: Rscript {0}
+      # - name: specially install pkgs for windows
+      #   if: runner.os == 'Windows'
+      #   run: |
+      #     install.packages("MCMCpack", type = "binary")
+      #     install.packages("igraph", type = "binary")
+      #     library(igraph)
+      #     packageVersion("igraph")
+      #     install.packages("maps", type = "binary")
+      #     library(maps)
+      #     packageVersion("maps")
+      #     install.packages("fields", type = "binary")
+      #     library(fields)
+      #     packageVersion("fields")
+      #     install.packages("DiagrammeR")
+      #     packageVersion("DiagrammeR")
+      #   shell: Rscript {0}
 
       - name: Install Miniconda
         run: |
@@ -148,23 +125,7 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", '--no-multiarch'), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-results
-          path: check
+          args: 'c("--no-manual", "--as-cran", "--no-multiarch")'
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -16,6 +16,10 @@ on:
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -38,7 +42,6 @@ jobs:
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RETICULATE_AUTOCONFIGURE: 'FALSE'
-      UPGRADE_PKGS: ${{ matrix.config.r == '3.4' || matrix.config.r == '3.5'}}
       TF_VERSION: '1.14.0'
 
     steps:
@@ -64,21 +67,14 @@ jobs:
             mvtnorm=?ignore-before-r=3.6.0
 
       - name: install mvtnorm and mcmcpack for R < 3.6
-        if: ${{ runner.os == 'Linux' && (matrix.config.r == '3.4' || matrix.config.r == '3.5') }}
+        if: runner.os == 'Linux' && (matrix.config.r == '3.4' || matrix.config.r == '3.5')
         run: |
-          Sys.getenv("UPGRADE_PKGS")
-          if (Sys.getenv("UPGRADE_PKGS")) {
-            pak::repo_add("MRAN@2017-03-06")
-            pak::pak(c("quantreg", "mvtnorm", "MCMCpack"))
-            # install.packages("remotes")
-            # install.packages("versions")
-            # versions::install.dates("quantreg", "2017-03-06")
-            # versions::install.dates("mvtnorm", "2017-03-06")
-            # versions::install.dates("MCMCpack", "2017-03-06")
-            packageVersion("quantreg")
-            packageVersion("mvtnorm")
-            packageVersion("MCMCpack")
-          }
+          pak::repo_add("MRAN@2017-03-06")
+          pak::pak(c("quantreg", "mvtnorm", "MCMCpack"))
+
+          packageVersion("quantreg")
+          packageVersion("mvtnorm")
+          packageVersion("MCMCpack")
         shell: Rscript {0}
 
       - name: Install Miniconda
@@ -91,13 +87,12 @@ jobs:
         run: |
           echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
 
-#  Perhaps here is where we can install / change the environment that we are
-# installing into? Can we call our own greta install functions here?
       - name: Install TensorFlow
         run: |
           cat("::group::Create Environment", sep = "\n")
           reticulate::conda_create('r-reticulate', packages = c('python==3.7'))
           cat("::endgroup::", sep = "\n")
+
           cat("::group::Install Tensorflow", sep = "\n")
           keras::install_keras(tensorflow = Sys.getenv('TF_VERSION'), 
               extra_packages = c('IPython', 'requests', 'certifi', 'urllib3', 'tensorflow-probability==0.7.0', 'numpy==1.16.4'))
@@ -106,10 +101,12 @@ jobs:
 
       - name: Python + TF details
         run: |
-          Rscript -e 'tensorflow::tf_config()'
-          Rscript -e 'tensorflow::tf_version()'
-          Rscript -e 'reticulate::py_module_available("tensorflow_probability")'
-          Rscript -e 'reticulate::py_config()'
+          tensorflow::tf_config()
+          tensorflow::tf_config()
+          tensorflow::tf_version()
+          reticulate::py_module_available("tensorflow_probability")
+          reticulate::py_config()
+        shell: Rscript {0}
 
       - name: Session info
         run: |


### PR DESCRIPTION
Hey!

This fixes the issue with the segfault, should this happen again just increment the cache number for the `setup-r-dependencies` action like so:
```yaml
      - uses: r-lib/actions/setup-r-dependencies@v2
        with:
          cache-version: 2
          extra-packages: |
            local::.
            any::keras
            any::rcmdcheck
            MCMCpack=?ignore-before-r=3.6.0
            quantreg=?ignore-before-r=3.6.0
            mvtnorm=?ignore-before-r=3.6.0
```
I have also updated the used r-lib/actions and cleaned up the workflow overall.