### PR TITLE
replace vapply(x, length) with lengths(x) 

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -185,7 +185,7 @@ check_dims <- function(..., target_dim = NULL) {
   } else {
 
     # otherwise, find the correct output dimension
-    dim_lengths <- vapply(dim_list, length, numeric(1))
+    dim_lengths <- lengths(dim_list)
     dim_list <- lapply(dim_list, pad_vector, to_length = max(dim_lengths))
     output_dim <- do.call(pmax, dim_list)
   }

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -268,10 +268,7 @@ dag_class <- R6Class(
       free_state <- get("free_state", envir = tfe)
 
       params <- self$example_parameters(free = TRUE)
-      lengths <- vapply(params,
-        function(x) length(x),
-        FUN.VALUE = 1L
-      )
+      lengths <- lengths(params)
 
       if (length(lengths) > 1) {
         args <- self$on_graph(tf$split(free_state, lengths, axis = 1L))

--- a/R/extract_replace_combine.R
+++ b/R/extract_replace_combine.R
@@ -263,7 +263,7 @@ cbind.greta_array <- function(...) {
   dots <- lapply(dots, as.greta_array)
 
   dims <- lapply(dots, dim)
-  ndims <- vapply(dims, length, FUN.VALUE = 1)
+  ndims <- lengths(dims)
   if (!all(ndims == 2)) {
     msg <- cli::format_error(
       "all {.cls greta_array}s must be two-dimensional"
@@ -304,7 +304,7 @@ rbind.greta_array <- function(...) {
   dots <- lapply(dots, as.greta_array)
 
   dims <- lapply(dots, dim)
-  ndims <- vapply(dims, length, FUN.VALUE = 1)
+  ndims <- lengths(dims)
   if (!all(ndims == 2)) {
     msg <- cli::format_error(
       "all {.cls greta_array}s must be two-dimensional"

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -96,7 +96,7 @@ operation_node <- R6Class(
       # the provided list of nodes arguments
       if (is.null(dim)) {
         dim_list <- lapply(dots, dim)
-        dim_lengths <- vapply(dim_list, length, numeric(1))
+        dim_lengths <- lengths(dim_list)
         dim_list <- lapply(dim_list, pad_vector, to_length = max(dim_lengths))
         dim <- do.call(pmax, dim_list)
       }


### PR DESCRIPTION
Found some examples of code that uses the pattern

```r
vapply(x, length, FUN.VALUE = "")
``` 
instead of 

```r
lengths(x)
```


resolves #527