### PR TITLE
ensures `worker` is defined, even when only 1 core is available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,4 @@
-# greta (development version)
-
-# greta 0.4.2.9000
+# greta 0.4.2.9000 (development version)
 
 ## Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # greta (development version)
 
+# greta 0.4.2.9000
+
+## Fixes
+
+* Issue where `future` and `parallely` packages error when a CPU with only one core is provided (#513, #516).
+
 # greta 0.4.2
 
 ## Fixes

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -551,11 +551,10 @@ check_future_plan <- function() {
 
       if (inherits(workers, "cluster")) {
         worker <- workers[[1]]
-      }
-
-      if (!is.null(worker$host)) {
-        localhosts <- c("localhost", "127.0.0.1", Sys.info()[["nodename"]])
-        plan_is$local <- worker$host %in% localhosts
+        if (!is.null(worker$host)) {
+          localhosts <- c("localhost", "127.0.0.1", Sys.info()[["nodename"]])
+          plan_is$local <- worker$host %in% localhosts
+        }
       }
     } else {
 

--- a/tests/testthat/test_future.R
+++ b/tests/testthat/test_future.R
@@ -1,3 +1,16 @@
+test_that("check_future_plan() works when only one core available", {
+  # temporarily set the envvar to have only 1 core available
+  withr::local_envvar("R_PARALLELLY_AVAILABLE_CORES" = "1")
+  op <- future::plan()
+  # put the future plan back as we found it
+  withr::defer(future::plan(op))
+  future::plan(future::multisession)
+
+  # one chain
+  expect_error(check_future_plan(), NA)
+
+})
+
 test_that("check_future_plan() works", {
   op <- future::plan()
   # put the future plan back as we found it


### PR DESCRIPTION
Should resolve #516 