### PR TITLE
Mcmc print neg 654

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,6 @@ Imports:
     progress (>= 1.2.0),
     R6,
     reticulate (>= 1.19.0),
-    rlang,
     tensorflow (>= 2.8.0),
     yesno
 Suggests:

--- a/R/greta_mcmc_list.R
+++ b/R/greta_mcmc_list.R
@@ -75,21 +75,32 @@ print.greta_mcmc_list <- function(x, ..., n = 5){
   )
 
   n_print <- getOption("greta.print_max") %||% n
+  remaining_draws <- n_iter - n_print
+  more_draws_than_can_print <- remaining_draws > 0
+  draws_can_be_printed <- remaining_draws <= 0
 
-  cli::cli_h1("Chain 1 (iterations 1...{n_print})")
+  if (more_draws_than_can_print) {
+    cli::cli_h1("Chain 1 (iterations 1...{n_print})")
+  }
+
+  if (draws_can_be_printed) {
+    cli::cli_h1("Chain 1 (iterations 1...{n_iter})")
+  }
 
   flat_mat <- as.matrix(x[[1]])
 
   draws_head <- head(flat_mat, n = n_print)
 
-  remaining_draws <- n_iter - n_print
   print(draws_head)
+
+  if (more_draws_than_can_print){
   cli::cli_alert_info(
     text = c(
       "i" = "{remaining_draws} more draws\n",
       "i" = "Use {.code print(n = ...)} to see more draws"
     )
   )
+  }
 
   cli::cli_rule()
 

--- a/tests/testthat/_snaps/greta_mcmc_list_class.md
+++ b/tests/testthat/_snaps/greta_mcmc_list_class.md
@@ -28,3 +28,239 @@
       i To see a summary of draws, run:
       `summary(greta_draws_object)`
 
+# greta_mcmc_list print method works with larger sample size
+
+    Code
+      draws
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 20
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...5) --------------------------------------------------
+    Output
+                    z
+      [1,] -0.3866553
+      [2,] -0.0766865
+      [3,] -0.4985052
+      [4,] -0.1992653
+      [5,]  0.3311871
+    Message
+      i 15 more draws
+      Use `print(n = ...)` to see more draws
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+
+---
+
+    Code
+      print(draws, n = 20)
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 20
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...20) -------------------------------------------------
+    Output
+                      z
+       [1,] -0.38665534
+       [2,] -0.07668650
+       [3,] -0.49850525
+       [4,] -0.19926534
+       [5,]  0.33118710
+       [6,]  0.29760025
+       [7,]  1.84788320
+       [8,]  0.90039200
+       [9,]  0.90039200
+      [10,] -0.01963587
+      [11,] -1.00686655
+      [12,] -0.87020380
+      [13,] -0.05158557
+      [14,] -0.50349852
+      [15,]  0.96660059
+      [16,] -1.16252818
+      [17,]  1.25533419
+      [18,] -1.26125546
+      [19,]  0.79295948
+      [20,]  0.37771644
+    Message
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+
+---
+
+    Code
+      print(draws, n = 19)
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 20
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...19) -------------------------------------------------
+    Output
+                      z
+       [1,] -0.38665534
+       [2,] -0.07668650
+       [3,] -0.49850525
+       [4,] -0.19926534
+       [5,]  0.33118710
+       [6,]  0.29760025
+       [7,]  1.84788320
+       [8,]  0.90039200
+       [9,]  0.90039200
+      [10,] -0.01963587
+      [11,] -1.00686655
+      [12,] -0.87020380
+      [13,] -0.05158557
+      [14,] -0.50349852
+      [15,]  0.96660059
+      [16,] -1.16252818
+      [17,]  1.25533419
+      [18,] -1.26125546
+      [19,]  0.79295948
+    Message
+      i 1 more draws
+      Use `print(n = ...)` to see more draws
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+
+---
+
+    Code
+      print(draws, n = 21)
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 20
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...20) -------------------------------------------------
+    Output
+                      z
+       [1,] -0.38665534
+       [2,] -0.07668650
+       [3,] -0.49850525
+       [4,] -0.19926534
+       [5,]  0.33118710
+       [6,]  0.29760025
+       [7,]  1.84788320
+       [8,]  0.90039200
+       [9,]  0.90039200
+      [10,] -0.01963587
+      [11,] -1.00686655
+      [12,] -0.87020380
+      [13,] -0.05158557
+      [14,] -0.50349852
+      [15,]  0.96660059
+      [16,] -1.16252818
+      [17,]  1.25533419
+      [18,] -1.26125546
+      [19,]  0.79295948
+      [20,]  0.37771644
+    Message
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+
+# greta_mcmc_list print method works with smaller sample size
+
+    Code
+      draws
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 2
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...2) --------------------------------------------------
+    Output
+                   z
+      [1,]  1.154891
+      [2,] -1.641963
+    Message
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+
+---
+
+    Code
+      print(draws, n = 1)
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 2
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...1) --------------------------------------------------
+    Output
+                  z
+      [1,] 1.154891
+    Message
+      i 1 more draws
+      Use `print(n = ...)` to see more draws
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+
+---
+
+    Code
+      print(draws, n = 3)
+    Message
+      
+      -- MCMC draws from greta -------------------------------------------------------
+      * Iterations = 2
+      * Chains = 4
+      * Thinning = 1
+      
+      -- Chain 1 (iterations 1...2) --------------------------------------------------
+    Output
+                   z
+      [1,]  1.154891
+      [2,] -1.641963
+    Message
+      --------------------------------------------------------------------------------
+      i View greta draw chain i with:
+      `greta_draws_object[[i]]`. 
+      E.g., view chain 1 with: 
+      `greta_draws_object[[1]]`.
+      i To see a summary of draws, run:
+      `summary(greta_draws_object)`
+

--- a/tests/testthat/test_greta_mcmc_list_class.R
+++ b/tests/testthat/test_greta_mcmc_list_class.R
@@ -109,3 +109,44 @@ test_that("greta_mcmc_list print method works", {
     draws
   )
 })
+
+test_that("greta_mcmc_list print method works with larger sample size", {
+  skip_if_not(check_tf_version())
+  samples <- 20
+  warmup <- 20
+  z <- normal(0, 1)
+  m <- model(z)
+  tensorflow::set_random_seed(2024-07-30-1233)
+  draws <- mcmc(m, warmup = warmup, n_samples = samples, verbose = FALSE)
+  expect_snapshot(
+    draws
+  )
+  expect_snapshot(
+    print(draws, n = 20)
+  )
+  expect_snapshot(
+    print(draws, n = 19)
+  )
+  expect_snapshot(
+    print(draws, n = 21)
+  )
+})
+
+test_that("greta_mcmc_list print method works with smaller sample size", {
+  skip_if_not(check_tf_version())
+  samples <- 2
+  warmup <- 2
+  z <- normal(0, 1)
+  m <- model(z)
+  tensorflow::set_random_seed(2024-07-30-34)
+  draws <- mcmc(m, warmup = warmup, n_samples = samples, verbose = FALSE)
+  expect_snapshot(
+    draws
+  )
+  expect_snapshot(
+    print(draws, n = 1)
+  )
+  expect_snapshot(
+    print(draws, n = 3)
+  )
+})


### PR DESCRIPTION
Resolves #654 

Now only prints number of remaining draws if it exceeds the max print amount.

# Before

``` r
library(greta)
#> 
#> Attaching package: 'greta'
#> The following objects are masked from 'package:stats':
#> 
#>     binomial, cov2cor, poisson
#> The following objects are masked from 'package:base':
#> 
#>     %*%, apply, backsolve, beta, chol2inv, colMeans, colSums, diag,
#>     eigen, forwardsolve, gamma, identity, rowMeans, rowSums, sweep,
#>     tapply
samples <- 10
warmup <- 10
z <- normal(0, 1)
#> ℹ Initialising python and checking dependencies, this may take a moment.
#> ✔ Initialising python and checking dependencies ... done!
#> 
m <- model(z)
tensorflow::set_random_seed(2024 - 07 - 30 - 1233)
draws <- mcmc(m, warmup = warmup, n_samples = samples, verbose = FALSE)
draws
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...5) ──────────────────────────────────────────────────
#>                 z
#> [1,]  0.316406028
#> [2,]  0.101987067
#> [3,] -0.004746295
#> [4,]  0.635565819
#> [5,] -0.685306000
#> ℹ 5 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 9)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...9) ──────────────────────────────────────────────────
#>                  z
#>  [1,]  0.316406028
#>  [2,]  0.101987067
#>  [3,] -0.004746295
#>  [4,]  0.635565819
#>  [5,] -0.685306000
#>  [6,] -1.623882840
#>  [7,]  1.434588933
#>  [8,]  0.308218840
#>  [9,] -0.004048234
#> ℹ 1 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 10)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...10) ─────────────────────────────────────────────────
#>                  z
#>  [1,]  0.316406028
#>  [2,]  0.101987067
#>  [3,] -0.004746295
#>  [4,]  0.635565819
#>  [5,] -0.685306000
#>  [6,] -1.623882840
#>  [7,]  1.434588933
#>  [8,]  0.308218840
#>  [9,] -0.004048234
#> [10,] -0.695800642
#> ℹ 0 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 11)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...11) ─────────────────────────────────────────────────
#>                  z
#>  [1,]  0.316406028
#>  [2,]  0.101987067
#>  [3,] -0.004746295
#>  [4,]  0.635565819
#>  [5,] -0.685306000
#>  [6,] -1.623882840
#>  [7,]  1.434588933
#>  [8,]  0.308218840
#>  [9,] -0.004048234
#> [10,] -0.695800642
#> ℹ -1 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`

samples <- 2
warmup <- 2
z <- normal(0, 1)
m <- model(z)
tensorflow::set_random_seed(2024 - 07 - 30 - 34)
draws <- mcmc(m, warmup = warmup, n_samples = samples, verbose = FALSE)
draws
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 2
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...5) ──────────────────────────────────────────────────
#>              z
#> [1,]  1.154891
#> [2,] -1.641963
#> ℹ -3 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 1)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 2
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...1) ──────────────────────────────────────────────────
#>             z
#> [1,] 1.154891
#> ℹ 1 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 3)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 2
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...3) ──────────────────────────────────────────────────
#>              z
#> [1,]  1.154891
#> [2,] -1.641963
#> ℹ -1 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
```

<sup>Created on 2024-07-30 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.4.0 (2024-04-24)
#>  os       macOS Sonoma 14.5
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Australia/Hobart
#>  date     2024-07-30
#>  pandoc   3.2.1 @ /opt/homebrew/bin/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  abind         1.4-5      2016-07-21 [1] CRAN (R 4.4.0)
#>  backports     1.5.0      2024-05-23 [1] CRAN (R 4.4.0)
#>  base64enc     0.1-3      2015-07-28 [1] CRAN (R 4.4.0)
#>  callr         3.7.6      2024-03-25 [1] CRAN (R 4.4.0)
#>  cli           3.6.3      2024-06-21 [1] CRAN (R 4.4.0)
#>  coda          0.19-4.1   2024-01-31 [1] CRAN (R 4.4.0)
#>  codetools     0.2-20     2024-03-31 [2] CRAN (R 4.4.0)
#>  crayon        1.5.3      2024-06-20 [1] CRAN (R 4.4.0)
#>  digest        0.6.36     2024-06-23 [1] CRAN (R 4.4.0)
#>  evaluate      0.24.0     2024-06-10 [1] CRAN (R 4.4.0)
#>  fastmap       1.2.0      2024-05-15 [1] CRAN (R 4.4.0)
#>  fs            1.6.4.9000 2024-06-26 [1] Github (r-lib/fs@714990b)
#>  future        1.33.2     2024-03-26 [1] CRAN (R 4.4.0)
#>  globals       0.16.3     2024-03-08 [1] CRAN (R 4.4.0)
#>  glue          1.7.0      2024-01-09 [1] CRAN (R 4.4.0)
#>  greta       * 0.4.5.9000 2024-07-30 [1] local
#>  hms           1.1.3      2023-03-21 [1] CRAN (R 4.4.0)
#>  htmltools     0.5.8.1    2024-04-04 [1] CRAN (R 4.4.0)
#>  jsonlite      1.8.8      2023-12-04 [1] CRAN (R 4.4.0)
#>  knitr         1.48       2024-07-07 [1] CRAN (R 4.4.0)
#>  lattice       0.22-6     2024-03-20 [2] CRAN (R 4.4.0)
#>  lifecycle     1.0.4      2023-11-07 [1] CRAN (R 4.4.0)
#>  listenv       0.9.1      2024-01-29 [1] CRAN (R 4.4.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.4.0)
#>  Matrix        1.7-0      2024-03-22 [2] CRAN (R 4.4.0)
#>  parallelly    1.37.1     2024-02-29 [1] CRAN (R 4.4.0)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.4.0)
#>  png           0.1-8      2022-11-29 [1] CRAN (R 4.4.0)
#>  prettyunits   1.2.0      2023-09-24 [1] CRAN (R 4.4.0)
#>  processx      3.8.4      2024-03-16 [1] CRAN (R 4.4.0)
#>  progress      1.2.3      2023-12-06 [1] CRAN (R 4.4.0)
#>  ps            1.7.7      2024-07-02 [1] CRAN (R 4.4.0)
#>  purrr         1.0.2      2023-08-10 [1] CRAN (R 4.4.0)
#>  R.cache       0.16.0     2022-07-21 [1] CRAN (R 4.4.0)
#>  R.methodsS3   1.8.2      2022-06-13 [1] CRAN (R 4.4.0)
#>  R.oo          1.26.0     2024-01-24 [1] CRAN (R 4.4.0)
#>  R.utils       2.12.3     2023-11-18 [1] CRAN (R 4.4.0)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.4.0)
#>  Rcpp          1.0.12     2024-01-09 [1] CRAN (R 4.4.0)
#>  reprex        2.1.0      2024-01-11 [1] CRAN (R 4.4.0)
#>  reticulate    1.36.1     2024-04-22 [1] CRAN (R 4.4.0)
#>  rlang         1.1.4      2024-06-04 [1] CRAN (R 4.4.0)
#>  rmarkdown     2.27       2024-05-17 [1] CRAN (R 4.4.0)
#>  rstudioapi    0.16.0     2024-03-24 [1] CRAN (R 4.4.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.4.0)
#>  styler        1.10.3     2024-04-07 [1] CRAN (R 4.4.0)
#>  tensorflow    2.16.0     2024-04-15 [1] CRAN (R 4.4.0)
#>  tfautograph   0.3.2      2021-09-17 [1] CRAN (R 4.4.0)
#>  tfruns        1.5.3      2024-04-19 [1] CRAN (R 4.4.0)
#>  vctrs         0.6.5      2023-12-01 [1] CRAN (R 4.4.0)
#>  whisker       0.4.1      2022-12-05 [1] CRAN (R 4.4.0)
#>  withr         3.0.0      2024-01-16 [1] CRAN (R 4.4.0)
#>  xfun          0.45       2024-06-16 [1] CRAN (R 4.4.0)
#>  yaml          2.3.9      2024-07-05 [1] CRAN (R 4.4.0)
#> 
#>  [1] /Users/nick/Library/R/arm64/4.4/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library
#> 
#> ─ Python configuration ───────────────────────────────────────────────────────
#>  python:         /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/bin/python
#>  libpython:      /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/libpython3.11.dylib
#>  pythonhome:     /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2:/Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2
#>  version:        3.11.9 | packaged by conda-forge | (main, Apr 19 2024, 18:34:54) [Clang 16.0.6 ]
#>  numpy:          /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/python3.11/site-packages/numpy
#>  numpy_version:  1.26.4
#>  tensorflow:     /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/python3.11/site-packages/tensorflow
#>  
#>  NOTE: Python version was forced by use_python() function
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>


# After

``` r
library(greta)
#> 
#> Attaching package: 'greta'
#> The following objects are masked from 'package:stats':
#> 
#>     binomial, cov2cor, poisson
#> The following objects are masked from 'package:base':
#> 
#>     %*%, apply, backsolve, beta, chol2inv, colMeans, colSums, diag,
#>     eigen, forwardsolve, gamma, identity, rowMeans, rowSums, sweep,
#>     tapply
samples <- 10
warmup <- 10
z <- normal(0, 1)
#> ℹ Initialising python and checking dependencies, this may take a moment.
#> ✔ Initialising python and checking dependencies ... done!
#> 
m <- model(z)
tensorflow::set_random_seed(2024 - 07 - 30 - 1233)
draws <- mcmc(m, warmup = warmup, n_samples = samples, verbose = FALSE)
draws
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...5) ──────────────────────────────────────────────────
#>                 z
#> [1,]  0.316406028
#> [2,]  0.101987067
#> [3,] -0.004746295
#> [4,]  0.635565819
#> [5,] -0.685306000
#> ℹ 5 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 9)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...9) ──────────────────────────────────────────────────
#>                  z
#>  [1,]  0.316406028
#>  [2,]  0.101987067
#>  [3,] -0.004746295
#>  [4,]  0.635565819
#>  [5,] -0.685306000
#>  [6,] -1.623882840
#>  [7,]  1.434588933
#>  [8,]  0.308218840
#>  [9,] -0.004048234
#> ℹ 1 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 10)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...10) ─────────────────────────────────────────────────
#>                  z
#>  [1,]  0.316406028
#>  [2,]  0.101987067
#>  [3,] -0.004746295
#>  [4,]  0.635565819
#>  [5,] -0.685306000
#>  [6,] -1.623882840
#>  [7,]  1.434588933
#>  [8,]  0.308218840
#>  [9,] -0.004048234
#> [10,] -0.695800642
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 11)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 10
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...10) ─────────────────────────────────────────────────
#>                  z
#>  [1,]  0.316406028
#>  [2,]  0.101987067
#>  [3,] -0.004746295
#>  [4,]  0.635565819
#>  [5,] -0.685306000
#>  [6,] -1.623882840
#>  [7,]  1.434588933
#>  [8,]  0.308218840
#>  [9,] -0.004048234
#> [10,] -0.695800642
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`

samples <- 2
warmup <- 2
z <- normal(0, 1)
m <- model(z)
tensorflow::set_random_seed(2024 - 07 - 30 - 34)
draws <- mcmc(m, warmup = warmup, n_samples = samples, verbose = FALSE)
draws
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 2
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...2) ──────────────────────────────────────────────────
#>              z
#> [1,]  1.154891
#> [2,] -1.641963
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 1)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 2
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...1) ──────────────────────────────────────────────────
#>             z
#> [1,] 1.154891
#> ℹ 1 more draws
#> Use `print(n = ...)` to see more draws
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
print(draws, n = 3)
#> 
#> ── MCMC draws from greta ───────────────────────────────────────────────────────
#> • Iterations = 2
#> • Chains = 4
#> • Thinning = 1
#> 
#> ── Chain 1 (iterations 1...2) ──────────────────────────────────────────────────
#>              z
#> [1,]  1.154891
#> [2,] -1.641963
#> ────────────────────────────────────────────────────────────────────────────────
#> ℹ View greta draw chain i with:
#> `greta_draws_object[[i]]`. 
#> E.g., view chain 1 with: 
#> `greta_draws_object[[1]]`.
#> ℹ To see a summary of draws, run:
#> `summary(greta_draws_object)`
```

<sup>Created on 2024-07-30 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.4.0 (2024-04-24)
#>  os       macOS Sonoma 14.5
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Australia/Hobart
#>  date     2024-07-30
#>  pandoc   3.2.1 @ /opt/homebrew/bin/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  abind         1.4-5      2016-07-21 [1] CRAN (R 4.4.0)
#>  backports     1.5.0      2024-05-23 [1] CRAN (R 4.4.0)
#>  base64enc     0.1-3      2015-07-28 [1] CRAN (R 4.4.0)
#>  callr         3.7.6      2024-03-25 [1] CRAN (R 4.4.0)
#>  cli           3.6.3      2024-06-21 [1] CRAN (R 4.4.0)
#>  coda          0.19-4.1   2024-01-31 [1] CRAN (R 4.4.0)
#>  codetools     0.2-20     2024-03-31 [2] CRAN (R 4.4.0)
#>  crayon        1.5.3      2024-06-20 [1] CRAN (R 4.4.0)
#>  digest        0.6.36     2024-06-23 [1] CRAN (R 4.4.0)
#>  evaluate      0.24.0     2024-06-10 [1] CRAN (R 4.4.0)
#>  fastmap       1.2.0      2024-05-15 [1] CRAN (R 4.4.0)
#>  fs            1.6.4.9000 2024-06-26 [1] Github (r-lib/fs@714990b)
#>  future        1.33.2     2024-03-26 [1] CRAN (R 4.4.0)
#>  globals       0.16.3     2024-03-08 [1] CRAN (R 4.4.0)
#>  glue          1.7.0      2024-01-09 [1] CRAN (R 4.4.0)
#>  greta       * 0.4.5.9000 2024-07-30 [1] local
#>  hms           1.1.3      2023-03-21 [1] CRAN (R 4.4.0)
#>  htmltools     0.5.8.1    2024-04-04 [1] CRAN (R 4.4.0)
#>  jsonlite      1.8.8      2023-12-04 [1] CRAN (R 4.4.0)
#>  knitr         1.48       2024-07-07 [1] CRAN (R 4.4.0)
#>  lattice       0.22-6     2024-03-20 [2] CRAN (R 4.4.0)
#>  lifecycle     1.0.4      2023-11-07 [1] CRAN (R 4.4.0)
#>  listenv       0.9.1      2024-01-29 [1] CRAN (R 4.4.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.4.0)
#>  Matrix        1.7-0      2024-03-22 [2] CRAN (R 4.4.0)
#>  parallelly    1.37.1     2024-02-29 [1] CRAN (R 4.4.0)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.4.0)
#>  png           0.1-8      2022-11-29 [1] CRAN (R 4.4.0)
#>  prettyunits   1.2.0      2023-09-24 [1] CRAN (R 4.4.0)
#>  processx      3.8.4      2024-03-16 [1] CRAN (R 4.4.0)
#>  progress      1.2.3      2023-12-06 [1] CRAN (R 4.4.0)
#>  ps            1.7.7      2024-07-02 [1] CRAN (R 4.4.0)
#>  purrr         1.0.2      2023-08-10 [1] CRAN (R 4.4.0)
#>  R.cache       0.16.0     2022-07-21 [1] CRAN (R 4.4.0)
#>  R.methodsS3   1.8.2      2022-06-13 [1] CRAN (R 4.4.0)
#>  R.oo          1.26.0     2024-01-24 [1] CRAN (R 4.4.0)
#>  R.utils       2.12.3     2023-11-18 [1] CRAN (R 4.4.0)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.4.0)
#>  Rcpp          1.0.12     2024-01-09 [1] CRAN (R 4.4.0)
#>  reprex        2.1.0      2024-01-11 [1] CRAN (R 4.4.0)
#>  reticulate    1.36.1     2024-04-22 [1] CRAN (R 4.4.0)
#>  rlang         1.1.4      2024-06-04 [1] CRAN (R 4.4.0)
#>  rmarkdown     2.27       2024-05-17 [1] CRAN (R 4.4.0)
#>  rstudioapi    0.16.0     2024-03-24 [1] CRAN (R 4.4.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.4.0)
#>  styler        1.10.3     2024-04-07 [1] CRAN (R 4.4.0)
#>  tensorflow    2.16.0     2024-04-15 [1] CRAN (R 4.4.0)
#>  tfautograph   0.3.2      2021-09-17 [1] CRAN (R 4.4.0)
#>  tfruns        1.5.3      2024-04-19 [1] CRAN (R 4.4.0)
#>  vctrs         0.6.5      2023-12-01 [1] CRAN (R 4.4.0)
#>  whisker       0.4.1      2022-12-05 [1] CRAN (R 4.4.0)
#>  withr         3.0.0      2024-01-16 [1] CRAN (R 4.4.0)
#>  xfun          0.45       2024-06-16 [1] CRAN (R 4.4.0)
#>  yaml          2.3.9      2024-07-05 [1] CRAN (R 4.4.0)
#> 
#>  [1] /Users/nick/Library/R/arm64/4.4/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library
#> 
#> ─ Python configuration ───────────────────────────────────────────────────────
#>  python:         /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/bin/python
#>  libpython:      /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/libpython3.11.dylib
#>  pythonhome:     /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2:/Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2
#>  version:        3.11.9 | packaged by conda-forge | (main, Apr 19 2024, 18:34:54) [Clang 16.0.6 ]
#>  numpy:          /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/python3.11/site-packages/numpy
#>  numpy_version:  1.26.4
#>  tensorflow:     /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/python3.11/site-packages/tensorflow
#>  
#>  NOTE: Python version was forced by use_python() function
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
