### PR TITLE
Use `expect_snapshot(error = TRUE, ...)` over `expect_snapshot_error`

### DIFF
--- a/tests/testthat/_snaps/calculate.md
+++ b/tests/testthat/_snaps/calculate.md
@@ -1,8 +1,12 @@
 # stochastic calculate works with greta_mcmc_list objects
 
-    `nsim` must be set to sample <greta array>s not in MCMC samples
-    the greta arrays `y` have distributions and are not in the MCMC samples, so cannot be calculated from the samples alone.
-    Set `nsim` if you want to sample them conditionally on the MCMC samples
+    Code
+      calc_a <- calculate(a, y, values = draws)
+    Condition
+      Error in `calculate_greta_mcmc_list()`:
+      ! `nsim` must be set to sample <greta array>s not in MCMC samples
+      the greta arrays `y` have distributions and are not in the MCMC samples, so cannot be calculated from the samples alone.
+      Set `nsim` if you want to sample them conditionally on the MCMC samples
 
 ---
 
@@ -10,69 +14,125 @@
 
 # calculate errors if the mcmc samples unrelated to target
 
-    the target <greta array>s do not appear to be connected to those in the <greta_mcmc_list> object
+    Code
+      calc_c <- calculate(c, values = draws)
+    Condition
+      Error in `calculate_greta_mcmc_list()`:
+      ! the target <greta array>s do not appear to be connected to those in the <greta_mcmc_list> object
 
 # stochastic calculate works with mcmc samples & new stochastics
 
-    `nsim` must be set to sample <greta array>s not in MCMC samples
-    the target <greta array>s are related to new variables that are not in the MCMC samples, so cannot be calculated from the samples alone.
-    Set `nsim` if you want to sample them conditionally on the MCMC samples
+    Code
+      calc_b <- calculate(b, values = draws)
+    Condition
+      Error in `calculate_greta_mcmc_list()`:
+      ! `nsim` must be set to sample <greta array>s not in MCMC samples
+      the target <greta array>s are related to new variables that are not in the MCMC samples, so cannot be calculated from the samples alone.
+      Set `nsim` if you want to sample them conditionally on the MCMC samples
 
 # calculate errors nicely if non-greta arrays are passed
 
-    `calculate()` arguments must be <greta_array>s
-    The following object passed to `calculate()` is not a <greta array>:
-    "x"
-    Perhaps you forgot to explicitly name other arguments?
+    Code
+      calc_y <- calculate(y, x, values = list(x = c(2, 1)))
+    Condition
+      Error in `calculate()`:
+      ! `calculate()` arguments must be <greta_array>s
+      The following object passed to `calculate()` is not a <greta array>:
+      "x"
+      Perhaps you forgot to explicitly name other arguments?
 
 ---
 
-    `calculate()` arguments must be <greta_array>s
-    The following object passed to `calculate()` is not a <greta array>:
-    "list(x = c(2, 1))"
-    Perhaps you forgot to explicitly name other arguments?
+    Code
+      calc_y <- calculate(y, list(x = c(2, 1)))
+    Condition
+      Error in `calculate()`:
+      ! `calculate()` arguments must be <greta_array>s
+      The following object passed to `calculate()` is not a <greta array>:
+      "list(x = c(2, 1))"
+      Perhaps you forgot to explicitly name other arguments?
 
 # calculate errors nicely if values for stochastics not passed
 
-    Please provide values for the following 1 <greta_array>:
-    `a`
+    Code
+      calc_y <- calculate(y, values = list(x = c(2, 1)))
+    Condition
+      Error in `lapply()`:
+      ! Please provide values for the following 1 <greta_array>:
+      `a`
 
 # calculate errors nicely if values have incorrect dimensions
 
-    a provided value has different number of elements than the <greta_array>
+    Code
+      calc_y <- calculate(y, values = list(a = c(1, 1)))
+    Condition
+      Error:
+      ! a provided value has different number of elements than the <greta_array>
 
 # calculate errors nicely with invalid batch sizes
 
-    `trace_batch_size` must be a single numeric value greater than or equal to 1
+    Code
+      calc_y <- calculate(y, values = draws, trace_batch_size = 0)
+    Condition
+      Error in `calculate_greta_mcmc_list()`:
+      ! `trace_batch_size` must be a single numeric value greater than or equal to 1
 
 ---
 
-    `trace_batch_size` must be a single numeric value greater than or equal to 1
+    Code
+      calc_y <- calculate(y, values = draws, trace_batch_size = NULL)
+    Condition
+      Error in `calculate_greta_mcmc_list()`:
+      ! `trace_batch_size` must be a single numeric value greater than or equal to 1
 
 ---
 
-    `trace_batch_size` must be a single numeric value greater than or equal to 1
+    Code
+      calc_y <- calculate(y, values = draws, trace_batch_size = NA)
+    Condition
+      Error in `calculate_greta_mcmc_list()`:
+      ! `trace_batch_size` must be a single numeric value greater than or equal to 1
 
 # calculate errors if distribution-free variables are not fixed
 
-    the target <greta_array>s are related to variables that do not have distributions so cannot be sampled
+    Code
+      calc_a <- calculate(a, y, nsim = 1)
+    Condition
+      Error in `calculate_list()`:
+      ! the target <greta_array>s are related to variables that do not have distributions so cannot be sampled
 
 # calculate errors if a distribution cannot be sampled from
 
-    Sampling is not yet implemented for "hypergeometric" distributions
+    Code
+      sims <- calculate(y, nsim = 1)
+    Condition
+      Error in `check_sampling_implemented()`:
+      ! Sampling is not yet implemented for "hypergeometric" distributions
 
 # calculate errors nicely if nsim is invalid
 
-    nsim must be a positive integer
-    However the value provided was: 0
+    Code
+      calc_x <- calculate(x, nsim = 0)
+    Condition
+      Error in `calculate()`:
+      ! nsim must be a positive integer
+      However the value provided was: 0
 
 ---
 
-    nsim must be a positive integer
-    However the value provided was: -1
+    Code
+      calc_x <- calculate(x, nsim = -1)
+    Condition
+      Error in `calculate()`:
+      ! nsim must be a positive integer
+      However the value provided was: -1
 
 ---
 
-    nsim must be a positive integer
-    However the value provided was: NA
+    Code
+      calc_x <- calculate(x, nsim = "five")
+    Condition
+      Error in `calculate()`:
+      ! nsim must be a positive integer
+      However the value provided was: NA
 

--- a/tests/testthat/_snaps/distributions.md
+++ b/tests/testthat/_snaps/distributions.md
@@ -57,27 +57,43 @@
 
 # poisson() and binomial() error informatively in glm
 
-    Wrong function name provided in another model
-    It looks like you're using greta's `poisson()` function in the family argument of another model.
-    Maybe you want to use `family = stats::poisson`,instead?
+    Code
+      glm(1 ~ 1, family = poisson)
+    Condition
+      Error in `family()`:
+      ! Wrong function name provided in another model
+      It looks like you're using greta's `poisson()` function in the family argument of another model.
+      Maybe you want to use `family = stats::poisson`,instead?
 
 ---
 
-    Wrong function name provided in another model
-    It looks like you're using greta's `binomial()` function in the family argument of another model.
-    Maybe you want to use `family = stats::binomial`,instead?
+    Code
+      glm(1 ~ 1, family = binomial)
+    Condition
+      Error in `family()`:
+      ! Wrong function name provided in another model
+      It looks like you're using greta's `binomial()` function in the family argument of another model.
+      Maybe you want to use `family = stats::binomial`,instead?
 
 ---
 
-    Wrong function name provided in another model
-    It looks like you're using greta's `poisson()` function in the family argument of another model.
-    Maybe you want to use `family = stats::poisson`,instead?
+    Code
+      glm(1 ~ 1, family = poisson())
+    Condition
+      Error in `poisson()`:
+      ! Wrong function name provided in another model
+      It looks like you're using greta's `poisson()` function in the family argument of another model.
+      Maybe you want to use `family = stats::poisson`,instead?
 
 ---
 
-    Wrong function name provided in another model
-    It looks like you're using greta's `poisson()` function in the family argument of another model.
-    Maybe you want to use `family = stats::poisson`,instead?
+    Code
+      glm(1 ~ 1, family = poisson("sqrt"))
+    Condition
+      Error in `poisson()`:
+      ! Wrong function name provided in another model
+      It looks like you're using greta's `poisson()` function in the family argument of another model.
+      Maybe you want to use `family = stats::poisson`,instead?
 
 # wishart distribution errors informatively
 
@@ -99,190 +115,334 @@
 
 # lkj_correlation distribution errors informatively
 
-    `eta` must be a positive scalar value, or a scalar <greta_array>
+    Code
+      lkj_correlation(-1, dim)
+    Condition
+      Error in `initialize()`:
+      ! `eta` must be a positive scalar value, or a scalar <greta_array>
 
 ---
 
-    `eta` must be a positive scalar value, or a scalar <greta_array>
+    Code
+      lkj_correlation(c(3, 3), dim)
+    Condition
+      Error in `initialize()`:
+      ! `eta` must be a positive scalar value, or a scalar <greta_array>
 
 ---
 
-    `eta` must be a scalar
-    However `eta` had dimensions: 2x1
+    Code
+      lkj_correlation(uniform(0, 1, dim = 2), dim)
+    Condition
+      Error in `initialize()`:
+      ! `eta` must be a scalar
+      However `eta` had dimensions: 2x1
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      lkj_correlation(4, dimension = -1)
+    Condition
+      Error in `initialize()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      lkj_correlation(4, dim = c(3, 3))
+    Condition
+      Error in `initialize()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      lkj_correlation(4, dim = NA)
+    Condition
+      Error in `initialize()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 # multivariate_normal distribution errors informatively
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      multivariate_normal(m_c, a)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      multivariate_normal(m_d, a)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    Dimensions of parameters not compatible with multivariate distribution parameters of multivariate distributions cannot have more than two dimensions
-    object `x` has dimensions: 3x3x3
+    Code
+      multivariate_normal(m_a, b)
+    Condition
+      Error in `lapply()`:
+      ! Dimensions of parameters not compatible with multivariate distribution parameters of multivariate distributions cannot have more than two dimensions
+      object `x` has dimensions: 3x3x3
 
 ---
 
-    Object must be 2D square array
-    x But it had dimension: "3x2"
+    Code
+      multivariate_normal(m_a, c)
+    Condition
+      Error in `lapply()`:
+      ! Object must be 2D square array
+      x But it had dimension: "3x2"
 
 ---
 
-    distribution dimensions do not match implied dimensions
-    The distribution dimension should be 3, but parameters implied dimensions: 3 vs 4
-    Multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      multivariate_normal(m_a, d)
+    Condition
+      Error in `check_dimension()`:
+      ! distribution dimensions do not match implied dimensions
+      The distribution dimension should be 3, but parameters implied dimensions: 3 vs 4
+      Multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      multivariate_normal(0, 1)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `-1` having class: <numeric> and length `1`
+    Code
+      multivariate_normal(m_a, a, n_realisations = -1)
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `-1` having class: <numeric> and length `1`
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
+    Code
+      multivariate_normal(m_a, a, n_realisations = c(1, 3))
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      multivariate_normal(m_a, a, dimension = -1)
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      multivariate_normal(m_a, a, dimension = c(1, 3))
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 # multinomial distribution errors informatively
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      multinomial(c(1), 1)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `-1` having class: <numeric> and length `1`
+    Code
+      multinomial(10, p_a, n_realisations = -1)
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `-1` having class: <numeric> and length `1`
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
+    Code
+      multinomial(10, p_a, n_realisations = c(1, 3))
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      multinomial(10, p_a, dimension = -1)
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      multinomial(10, p_a, dimension = c(1, 3))
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 # categorical distribution errors informatively
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      categorical(1)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `-1` having class: <numeric> and length `1`
+    Code
+      categorical(p_a, n_realisations = -1)
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `-1` having class: <numeric> and length `1`
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
+    Code
+      categorical(p_a, n_realisations = c(1, 3))
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      categorical(p_a, dimension = -1)
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      categorical(p_a, dimension = c(1, 3))
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 # dirichlet distribution errors informatively
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      dirichlet(1)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `-1` having class: <numeric> and length `1`
+    Code
+      dirichlet(alpha_a, n_realisations = -1)
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `-1` having class: <numeric> and length `1`
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
+    Code
+      dirichlet(alpha_a, n_realisations = c(1, 3))
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      dirichlet(alpha_a, dimension = -1)
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      dirichlet(alpha_a, dimension = c(1, 3))
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 # dirichlet-multinomial distribution errors informatively
 
-    the dimension of this distribution must be at least 2, but was 1
-    multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
+    Code
+      dirichlet_multinomial(c(1), 1)
+    Condition
+      Error in `check_dimension()`:
+      ! the dimension of this distribution must be at least 2, but was 1
+      multivariate distributions treat each row as a separate realisation - perhaps you need to transpose something?
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `-1` having class: <numeric> and length `1`
+    Code
+      dirichlet_multinomial(10, alpha_a, n_realisations = -1)
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `-1` having class: <numeric> and length `1`
 
 ---
 
-    `n_realisations is not a positive scalar interger`
-    `n_realisations` must be a positive scalar integer giving the number of rows of the output
-    x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
+    Code
+      dirichlet_multinomial(10, alpha_a, n_realisations = c(1, 3))
+    Condition
+      Error in `check_n_realisations()`:
+      ! `n_realisations is not a positive scalar interger`
+      `n_realisations` must be a positive scalar integer giving the number of rows of the output
+      x We see `n_realisations` = `1` and `3` having class: <numeric> and length `2`
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      dirichlet_multinomial(10, alpha_a, dimension = -1)
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 
 ---
 
-    `dimension` must be a positive scalar integer giving the dimension of the distribution
-    `dim(target)` returns:
+    Code
+      dirichlet_multinomial(10, alpha_a, dimension = c(1, 3))
+    Condition
+      Error in `check_multivariate_dims()`:
+      ! `dimension` must be a positive scalar integer giving the dimension of the distribution
+      `dim(target)` returns:
 

--- a/tests/testthat/_snaps/extract_replace_combine.md
+++ b/tests/testthat/_snaps/extract_replace_combine.md
@@ -1,59 +1,115 @@
 # abind errors informatively
 
-    all <greta_array>s must have the same dimensions except on the `along` dimension
-    However, dimension 1 had varying sizes: 5 and 1
+    Code
+      abind(a, b)
+    Condition
+      Error in `abind()`:
+      ! all <greta_array>s must have the same dimensions except on the `along` dimension
+      However, dimension 1 had varying sizes: 5 and 1
 
 ---
 
-    `along` must be between 0 and 4
-    Instead `along` was 5
+    Code
+      abind(a, c, along = 5)
+    Condition
+      Error in `abind()`:
+      ! `along` must be between 0 and 4
+      Instead `along` was 5
 
 # assign errors on variable greta arrays
 
-    cannot replace values in a variable <greta_array>
+    Code
+      z[1] <- 3
+    Condition
+      Error in `[<-`:
+      ! cannot replace values in a variable <greta_array>
 
 # rbind and cbind give informative error messages
 
-    all <greta_array>s must be have the same number of columns
+    Code
+      rbind(a, b)
+    Condition
+      Error in `rbind()`:
+      ! all <greta_array>s must be have the same number of columns
 
 ---
 
-    all <greta_array>s must be have the same number of rows
+    Code
+      cbind(a, b)
+    Condition
+      Error in `cbind()`:
+      ! all <greta_array>s must be have the same number of rows
 
 # replacement gives informative error messages
 
-    number of items to replace is not a multiple of replacement length
+    Code
+      x[1:2, , 1] <- seq_len(3)
+    Condition
+      Error in `[<-`:
+      ! number of items to replace is not a multiple of replacement length
 
 ---
 
-    subscript out of bounds
+    Code
+      x[1, 1, 3] <- 1
+    Condition
+      Error:
+      ! subscript out of bounds
 
 ---
 
-    subscript out of bounds
+    Code
+      x[3] <- 1
+    Condition
+      Error in `[<-`:
+      ! subscript out of bounds
 
 # extraction gives informative error messages
 
-    subscript out of bounds
+    Code
+      x[1, 1, 3]
+    Condition
+      Error:
+      ! subscript out of bounds
 
 ---
 
-    subscript out of bounds
+    Code
+      x[3]
+    Condition
+      Error in `x[3]`:
+      ! subscript out of bounds
 
 # dim<- errors as expected
 
-    length-0 dimension vector is invalid
+    Code
+      dim(x) <- pi[0]
+    Condition
+      Error in `dim<-`:
+      ! length-0 dimension vector is invalid
 
 ---
 
-    the dims contain missing values
+    Code
+      dim(x) <- c(1, NA)
+    Condition
+      Error in `dim<-`:
+      ! the dims contain missing values
 
 ---
 
-    the dims contain negative values:
-    `dim(x)` returns 3 and 4
+    Code
+      dim(x) <- c(1, -1)
+    Condition
+      Error in `dim<-`:
+      ! the dims contain negative values:
+      `dim(x)` returns 3 and 4
 
 ---
 
-    dims [product 13] do not match the length of object [12]
+    Code
+      dim(x) <- 13
+    Condition
+      Error in `dim<-`:
+      ! dims [product 13] do not match the length of object [12]
 

--- a/tests/testthat/_snaps/functions.md
+++ b/tests/testthat/_snaps/functions.md
@@ -1,50 +1,94 @@
 # cummax and cummin functions error informatively
 
-    `cummax()` not yet implemented for greta
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! `cummax()` not yet implemented for greta
 
 ---
 
-    `cummin()` not yet implemented for greta
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! `cummin()` not yet implemented for greta
 
 # complex number functions error informatively
 
-    greta does not yet support complex numbers
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! greta does not yet support complex numbers
 
 ---
 
-    greta does not yet support complex numbers
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! greta does not yet support complex numbers
 
 ---
 
-    greta does not yet support complex numbers
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! greta does not yet support complex numbers
 
 ---
 
-    greta does not yet support complex numbers
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! greta does not yet support complex numbers
 
 ---
 
-    greta does not yet support complex numbers
+    Code
+      fun(x)
+    Condition
+      Error:
+      ! greta does not yet support complex numbers
 
 # cumulative functions error as expected
 
-    `x` must be a column vector
-    but `x` has dimensions 1x5
+    Code
+      cumsum(a)
+    Condition
+      Error:
+      ! `x` must be a column vector
+      but `x` has dimensions 1x5
 
 ---
 
-    `x` must be a column vector
-    but `x` has dimensions 5x1x1
+    Code
+      cumsum(b)
+    Condition
+      Error:
+      ! `x` must be a column vector
+      but `x` has dimensions 5x1x1
 
 ---
 
-    `x` must be a column vector
-    but `x` has dimensions 1x5
+    Code
+      cumprod(a)
+    Condition
+      Error:
+      ! `x` must be a column vector
+      but `x` has dimensions 1x5
 
 ---
 
-    `x` must be a column vector
-    but `x` has dimensions 5x1x1
+    Code
+      cumprod(b)
+    Condition
+      Error:
+      ! `x` must be a column vector
+      but `x` has dimensions 5x1x1
 
 # solve and sweep and kronecker error as expected
 
@@ -155,49 +199,93 @@
 
 # colSums etc. error as expected
 
-    invalid `dims`
+    Code
+      colSums(x, dims = 3)
+    Condition
+      Error in `rowcol_idx()`:
+      ! invalid `dims`
 
 ---
 
-    invalid `dims`
+    Code
+      rowSums(x, dims = 3)
+    Condition
+      Error in `rowcol_idx()`:
+      ! invalid `dims`
 
 ---
 
-    invalid `dims`
+    Code
+      colMeans(x, dims = 3)
+    Condition
+      Error in `rowcol_idx()`:
+      ! invalid `dims`
 
 ---
 
-    invalid `dims`
+    Code
+      rowMeans(x, dims = 3)
+    Condition
+      Error in `rowcol_idx()`:
+      ! invalid `dims`
 
 # forwardsolve and backsolve error as expected
 
-    `1` must equal `ncol(l)` for <greta_array>s
+    Code
+      forwardsolve(a, b, k = 1)
+    Condition
+      Error in `forwardsolve()`:
+      ! `1` must equal `ncol(l)` for <greta_array>s
 
 ---
 
-    `1` must equal `ncol(r)` for <greta_array>s
+    Code
+      backsolve(a, b, k = 1)
+    Condition
+      Error in `backsolve()`:
+      ! `1` must equal `ncol(r)` for <greta_array>s
 
 ---
 
-    `transpose` must be FALSE for <greta_array>s
+    Code
+      forwardsolve(a, b, transpose = TRUE)
+    Condition
+      Error in `forwardsolve()`:
+      ! `transpose` must be FALSE for <greta_array>s
 
 ---
 
-    `transpose` must be FALSE for <greta_array>s
+    Code
+      backsolve(a, b, transpose = TRUE)
+    Condition
+      Error in `backsolve()`:
+      ! `transpose` must be FALSE for <greta_array>s
 
 # tapply errors as expected
 
-    `x` must be 2D <greta_array> with one column
-    However `x` has dimensions 10x2
+    Code
+      tapply(b, group, "sum")
+    Condition
+      Error in `tapply()`:
+      ! `x` must be 2D <greta_array> with one column
+      However `x` has dimensions 10x2
 
 ---
 
-    `INDEX` cannot be a <greta_array>
+    Code
+      tapply(a, as_data(group), "sum")
+    Condition
+      Error in `check_not_greta_array()`:
+      ! `INDEX` cannot be a <greta_array>
 
 # ignored options are errored/warned about
 
-    the "digits" argument of `round()` cannot be set for <greta_array>s
-    <greta_array>s can only be rounded to the nearest integer, so the "digits" argument cannot be set
+    Code
+      round(x, 2)
+    Condition
+      Error:
+      ! the "digits" argument of `round()` cannot be set for <greta_array>s
+      <greta_array>s can only be rounded to the nearest integer, so the "digits" argument cannot be set
 
 ---
 
@@ -217,43 +305,79 @@
 
 # incorrect dimensions are errored about
 
-    only 2D arrays can be transposed
+    Code
+      t(x)
+    Condition
+      Error in `t()`:
+      ! only 2D arrays can be transposed
 
 ---
 
-    `perm` must be a reordering of the dimensions: 1, 2, and 3
-    but was: 2 and 1
+    Code
+      aperm(x, 2:1)
+    Condition
+      Error in `aperm()`:
+      ! `perm` must be a reordering of the dimensions: 1, 2, and 3
+      but was: 2 and 1
 
 ---
 
-    only two-dimensional, square, symmetric <greta_array>s can be Cholesky decomposed
-    `dim(x)` returns: 3, 3, and 3
+    Code
+      chol(x)
+    Condition
+      Error in `chol()`:
+      ! only two-dimensional, square, symmetric <greta_array>s can be Cholesky decomposed
+      `dim(x)` returns: 3, 3, and 3
 
 ---
 
-    only two-dimensional, square, symmetric <greta_array>s can be Cholesky decomposed
-    `dim(x)` returns: 3 and 4
+    Code
+      chol(y)
+    Condition
+      Error in `chol()`:
+      ! only two-dimensional, square, symmetric <greta_array>s can be Cholesky decomposed
+      `dim(x)` returns: 3 and 4
 
 ---
 
-    `chol2symm()` must have two-dimensional, square, upper-triangular <greta_array>s
-    `dim(x)` returns: 3, 3, and 3
+    Code
+      chol2symm(x)
+    Condition
+      Error in `chol2symm()`:
+      ! `chol2symm()` must have two-dimensional, square, upper-triangular <greta_array>s
+      `dim(x)` returns: 3, 3, and 3
 
 ---
 
-    `chol2symm()` must have two-dimensional, square, upper-triangular <greta_array>s
-    `dim(x)` returns: 3 and 4
+    Code
+      chol2symm(y)
+    Condition
+      Error in `chol2symm()`:
+      ! `chol2symm()` must have two-dimensional, square, upper-triangular <greta_array>s
+      `dim(x)` returns: 3 and 4
 
 ---
 
-    only two-dimensional, square, symmetric <greta_array>s can be eigendecomposed
+    Code
+      eigen(x)
+    Condition
+      Error in `eigen()`:
+      ! only two-dimensional, square, symmetric <greta_array>s can be eigendecomposed
 
 ---
 
-    only two-dimensional, square, symmetric <greta_array>s can be eigendecomposed
+    Code
+      eigen(y)
+    Condition
+      Error in `eigen()`:
+      ! only two-dimensional, square, symmetric <greta_array>s can be eigendecomposed
 
 ---
 
-    `x1` and `x2` must have the same number of columns
-    However `ncol(x1)` = 1 and `ncol(x2)` = 4
+    Code
+      rdist(x, y)
+    Condition
+      Error in `rdist()`:
+      ! `x1` and `x2` must have the same number of columns
+      However `ncol(x1)` = 1 and `ncol(x2)` = 4
 

--- a/tests/testthat/_snaps/future.md
+++ b/tests/testthat/_snaps/future.md
@@ -45,17 +45,33 @@
 
 ---
 
-    parallel mcmc samplers cannot be run with `plan(multicore)`
+    Code
+      check_future_plan()
+    Condition
+      Error:
+      ! parallel mcmc samplers cannot be run with `plan(multicore)`
 
 ---
 
-    parallel mcmc samplers cannot be run with a fork cluster
+    Code
+      check_future_plan()
+    Condition
+      Error in `test_if_forked_cluster()`:
+      ! parallel mcmc samplers cannot be run with a fork cluster
 
 ---
 
-    parallel mcmc samplers cannot be run with `plan(multicore)`
+    Code
+      mcmc(m, verbose = FALSE)
+    Condition
+      Error in `run_samplers()`:
+      ! parallel mcmc samplers cannot be run with `plan(multicore)`
 
 ---
 
-    parallel mcmc samplers cannot be run with a fork cluster
+    Code
+      mcmc(m, verbose = FALSE)
+    Condition
+      Error in `test_if_forked_cluster()`:
+      ! parallel mcmc samplers cannot be run with a fork cluster
 

--- a/tests/testthat/_snaps/iid_samples.md
+++ b/tests/testthat/_snaps/iid_samples.md
@@ -1,8 +1,17 @@
 # distributions without RNG error nicely
 
-    Sampling is not yet implemented for "hypergeometric" distributions
+    Code
+      compare_iid_samples(hypergeometric, rhyper, parameters = list(m = 11, n = 8, k = 5))
+    Condition
+      Error in `check_sampling_implemented()`:
+      ! Sampling is not yet implemented for "hypergeometric" distributions
 
 ---
 
-    Sampling is not yet implemented for truncated "f" distributions
+    Code
+      compare_iid_samples(f, rtf, parameters = list(df1 = 4, df2 = 1, truncation = c(
+        2, 3)))
+    Condition
+      Error in `dag$draw_sample()`:
+      ! Sampling is not yet implemented for truncated "f" distributions
 

--- a/tests/testthat/_snaps/inference.md
+++ b/tests/testthat/_snaps/inference.md
@@ -1,21 +1,40 @@
 # bad mcmc proposals are rejected
 
-    The log density could not be evaluated at these initial values
-    Try using these initials as the `values` argument in `calculate()` to see what values of subsequent <greta_array>s these initial values lead to.
+    Code
+      draws <- mcmc(m, chains = 1, n_samples = 2, warmup = 0, verbose = FALSE,
+        initial_values = initials(z = 1e+120))
+    Condition
+      Error in `self$check_valid_parameters()`:
+      ! The log density could not be evaluated at these initial values
+      Try using these initials as the `values` argument in `calculate()` to see what values of subsequent <greta_array>s these initial values lead to.
 
 ---
 
-    Could not find reasonable starting values after 20 attempts.
-    Please specify initial values manually via the `initial_values` argument
+    Code
+      mcmc(m, chains = 1, n_samples = 1, warmup = 0, verbose = FALSE)
+    Condition
+      Error in `self$check_reasonable_starting_values()`:
+      ! Could not find reasonable starting values after 20 attempts.
+      Please specify initial values manually via the `initial_values` argument
 
 # mcmc handles initial values nicely
 
-    The number of provided initial values does not match chains
-    3 sets of initial values were provided, but there are 2 chains
+    Code
+      draws <- mcmc(m, warmup = 10, n_samples = 10, verbose = FALSE, chains = 2,
+        initial_values = inits)
+    Condition
+      Error in `prep_initials()`:
+      ! The number of provided initial values does not match chains
+      3 sets of initial values were provided, but there are 2 chains
 
 ---
 
-    The initial values provided have different dimensions than the named <greta_array>s
+    Code
+      draws <- mcmc(m, warmup = 10, n_samples = 10, verbose = FALSE, chains = 2,
+        initial_values = inits)
+    Condition
+      Error in `FUN()`:
+      ! The initial values provided have different dimensions than the named <greta_array>s
 
 ---
 
@@ -66,18 +85,29 @@
 
 # model errors nicely
 
-    `model()` arguments must be <greta_array>s
-    The following object passed to `model()` is not a <greta array>:
-    "a"
-    
+    Code
+      model(a, b)
+    Condition
+      Error in `model()`:
+      ! `model()` arguments must be <greta_array>s
+      The following object passed to `model()` is not a <greta array>:
+      "a"
 
 # initials works
 
-    initial values must be numeric
+    Code
+      initials(a = FALSE)
+    Condition
+      Error in `initials()`:
+      ! initial values must be numeric
 
 ---
 
-    All initial values must be named
+    Code
+      initials(FALSE)
+    Condition
+      Error in `initials()`:
+      ! All initial values must be named
 
 ---
 
@@ -93,36 +123,68 @@
 
 # prep_initials errors informatively
 
-    `initial_values` must be an initials object created with `initials()`, or a simple list of initials objects
+    Code
+      mcmc(m, initial_values = FALSE, verbose = FALSE)
+    Condition
+      Error in `prep_initials()`:
+      ! `initial_values` must be an initials object created with `initials()`, or a simple list of initials objects
 
 ---
 
-    `initial_values` must be an initials object created with `initials()`, or a simple list of initials objects
+    Code
+      mcmc(m, initial_values = list(FALSE), verbose = FALSE)
+    Condition
+      Error in `prep_initials()`:
+      ! `initial_values` must be an initials object created with `initials()`, or a simple list of initials objects
 
 ---
 
-    Some <greta_array>s passed to `initials()` are not associated with the model:
-    `g`
+    Code
+      mcmc(m, chains = 1, initial_values = initials(g = 1), verbose = FALSE)
+    Condition
+      Error in `check_greta_arrays_associated_with_model()`:
+      ! Some <greta_array>s passed to `initials()` are not associated with the model:
+      `g`
 
 ---
 
-    Initial values can only be set for variable <greta_array>s
+    Code
+      mcmc(m, chains = 1, initial_values = initials(f = 1), verbose = FALSE)
+    Condition
+      Error in `check_nodes_all_variable()`:
+      ! Initial values can only be set for variable <greta_array>s
 
 ---
 
-    Initial values can only be set for variable <greta_array>s
+    Code
+      mcmc(m, chains = 1, initial_values = initials(z = 1), verbose = FALSE)
+    Condition
+      Error in `check_nodes_all_variable()`:
+      ! Initial values can only be set for variable <greta_array>s
 
 ---
 
-    Some provided initial values are outside the range of values their variables can take
+    Code
+      mcmc(m, chains = 1, initial_values = initials(b = -1), verbose = FALSE)
+    Condition
+      Error in `unsupported_error()`:
+      ! Some provided initial values are outside the range of values their variables can take
 
 ---
 
-    Some provided initial values are outside the range of values their variables can take
+    Code
+      mcmc(m, chains = 1, initial_values = initials(d = -1), verbose = FALSE)
+    Condition
+      Error in `unsupported_error()`:
+      ! Some provided initial values are outside the range of values their variables can take
 
 ---
 
-    Some provided initial values are outside the range of values their variables can take
+    Code
+      mcmc(m, chains = 1, initial_values = initials(e = 2), verbose = FALSE)
+    Condition
+      Error in `unsupported_error()`:
+      ! Some provided initial values are outside the range of values their variables can take
 
 # samplers print informatively
 

--- a/tests/testthat/_snaps/install_greta_deps.md
+++ b/tests/testthat/_snaps/install_greta_deps.md
@@ -1,4 +1,12 @@
 # install_greta_deps errors appropriately
 
-    Stopping as installation of greta dependencies took longer than 0.001 minutes You can increase the timeout time by increasing the `timeout` argument. For example, to wait 5 minutes: `install_greta_deps(timeout = 5)` Alternatively, you can perform the entire installation with: `reticulate::install_miniconda()` Then: `reticulate::conda_create(envname = 'greta-env-tf2', python_version = '3.8')` Then: `reticulate::py_install( packages = c( 'numpy', 'tensorflow', 'tensorflow-probability' ), pip = TRUE )` Then, restart R, and load greta with: `library(greta)`
+    Code
+      install_greta_deps(timeout = 0.001)
+    Message
+      i Installing python modules into 'greta-env-tf2' conda environment, this may ...
+      x Installing python modules into 'greta-env-tf2' conda environment, this may ...
+      
+    Condition
+      Error in `new_install_process()`:
+      ! Stopping as installation of greta dependencies took longer than 0.001 minutes You can increase the timeout time by increasing the `timeout` argument. For example, to wait 5 minutes: `install_greta_deps(timeout = 5)` Alternatively, you can perform the entire installation with: `reticulate::install_miniconda()` Then: `reticulate::conda_create(envname = 'greta-env-tf2', python_version = '3.8')` Then: `reticulate::py_install( packages = c( 'numpy', 'tensorflow', 'tensorflow-probability' ), pip = TRUE )` Then, restart R, and load greta with: `library(greta)`
 

--- a/tests/testthat/_snaps/joint.md
+++ b/tests/testthat/_snaps/joint.md
@@ -1,18 +1,34 @@
 # joint of fixed and continuous distributions errors
 
-    Cannot construct a joint distribution from a combination of discrete and continuous distributions
+    Code
+      joint(bernoulli(0.5), normal(0, 1))
+    Condition
+      Error in `initialize()`:
+      ! Cannot construct a joint distribution from a combination of discrete and continuous distributions
 
 # joint with insufficient distributions errors
 
-    `joint()` must be passed at least 2 distributions
-    The number of distributions passed was: 1
+    Code
+      joint(normal(0, 2))
+    Condition
+      Error in `initialize()`:
+      ! `joint()` must be passed at least 2 distributions
+      The number of distributions passed was: 1
 
 ---
 
-    `joint()` must be passed at least 2 distributions
-    The number of distributions passed was: 0
+    Code
+      joint()
+    Condition
+      Error in `initialize()`:
+      ! `joint()` must be passed at least 2 distributions
+      The number of distributions passed was: 0
 
 # joint with non-scalar distributions errors
 
-    `joint()` only accepts probability distributions over scalars
+    Code
+      joint(normal(0, 2, dim = 3), normal(0, 1, dim = 3))
+    Condition
+      Error in `initialize()`:
+      ! `joint()` only accepts probability distributions over scalars
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -1,12 +1,16 @@
 # check_tf_version works
 
-    x The expected python packages are not available
-    i We recommend installing them (in a fresh R session) with:
-    `install_greta_deps()`
-    or
-    `reinstall_greta_deps()`
-    (Note: Your R session should not have initialised Tensorflow yet.)
-    i For more information, see `?install_greta_deps`
+    Code
+      check_tf_version("error")
+    Condition
+      Error in `check_tf_version()`:
+      ! x The expected python packages are not available
+      i We recommend installing them (in a fresh R session) with:
+      `install_greta_deps()`
+      or
+      `reinstall_greta_deps()`
+      (Note: Your R session should not have initialised Tensorflow yet.)
+      i For more information, see `?install_greta_deps`
 
 ---
 
@@ -33,43 +37,83 @@
 
 # define and mcmc error informatively
 
-    none of the <greta_array>s in the model are associated with a probability density, so a model cannot be defined
+    Code
+      model(variable())
+    Condition
+      Error in `model()`:
+      ! none of the <greta_array>s in the model are associated with a probability density, so a model cannot be defined
 
 ---
 
-    none of the <greta_array>s in the model are associated with a probability density, so a model cannot be defined
+    Code
+      model(x)
+    Condition
+      Error in `model()`:
+      ! none of the <greta_array>s in the model are associated with a probability density, so a model cannot be defined
 
 ---
 
-    could not find any non-data <greta_array>s
+    Code
+      model()
+    Condition
+      Error in `model()`:
+      ! could not find any non-data <greta_array>s
 
 ---
 
-    Model contains a discrete random variable that doesn't have a fixed value, so inference cannot be carried out.
+    Code
+      model(bernoulli(0.5))
+    Condition
+      Error in `check_unfixed_discrete_distributions()`:
+      ! Model contains a discrete random variable that doesn't have a fixed value, so inference cannot be carried out.
 
 ---
 
-    none of the <greta_array>s in the model are unknown, so a model cannot be defined
+    Code
+      model(x)
+    Condition
+      Error in `model()`:
+      ! none of the <greta_array>s in the model are unknown, so a model cannot be defined
 
 ---
 
-    Data <greta_array>s cannot be sampled
-    `x` is a data <greta_array>(s)
+    Code
+      draws <- mcmc(m, verbose = FALSE)
+    Condition
+      Error in `mcmc()`:
+      ! Data <greta_array>s cannot be sampled
+      `x` is a data <greta_array>(s)
 
 # check_dims errors informatively
 
-    incompatible dimensions: 3x3, 2x2
+    Code
+      greta:::check_dims(a, c)
+    Condition
+      Error:
+      ! incompatible dimensions: 3x3, 2x2
 
 # disjoint graphs are checked
 
-    the model contains 2 disjoint graphs one or more of these sub-graphs does not contain any <greta_array>s that are associated with a probability density, so a model cannot be defined
+    Code
+      m <- model(a, b, c)
+    Condition
+      Error in `model()`:
+      ! the model contains 2 disjoint graphs one or more of these sub-graphs does not contain any <greta_array>s that are associated with a probability density, so a model cannot be defined
 
 ---
 
-    the model contains 2 disjoint graphs one or more of these sub-graphs does not contain any <greta_array>s that are unknown, so a model cannot be defined
+    Code
+      m <- model(a, b, d)
+    Condition
+      Error in `model()`:
+      ! the model contains 2 disjoint graphs one or more of these sub-graphs does not contain any <greta_array>s that are unknown, so a model cannot be defined
 
 # cleanly() handles TF errors nicely
 
-    greta hit a tensorflow error:
-    Error in other_stop(): Fetchez la vache!
+    Code
+      cleanly(other_stop())
+    Condition
+      Error in `cleanly()`:
+      ! greta hit a tensorflow error:
+      Error in other_stop(): Fetchez la vache!
 

--- a/tests/testthat/_snaps/mixture.md
+++ b/tests/testthat/_snaps/mixture.md
@@ -1,35 +1,64 @@
 # mixtures of fixed and continuous distributions errors
 
-    Cannot construct a mixture distribution from a combination of discrete and continuous distributions
+    Code
+      mixture(bernoulli(0.5), normal(0, 1), weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! Cannot construct a mixture distribution from a combination of discrete and continuous distributions
 
 # mixtures of multivariate and univariate errors
 
-    Cannot construct a mixture from a combination of multivariate and univariate distributions
+    Code
+      mixture(multivariate_normal(zeros(1, 3), diag(3)), normal(0, 1, dim = c(1, 3)),
+      weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! Cannot construct a mixture from a combination of multivariate and univariate distributions
 
 # mixtures of supports errors
 
-    Component distributions must have the same support
-    However the component distributions have different support:
-    "0 to Inf vs. -Inf to Inf"
+    Code
+      mixture(normal(0, 1, truncation = c(0, Inf)), normal(0, 1), weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! Component distributions must have the same support
+      However the component distributions have different support:
+      "0 to Inf vs. -Inf to Inf"
 
 ---
 
-    Component distributions must have the same support
-    However the component distributions have different support:
-    "0 to Inf vs. -Inf to Inf"
+    Code
+      mixture(lognormal(0, 1), normal(0, 1), weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! Component distributions must have the same support
+      However the component distributions have different support:
+      "0 to Inf vs. -Inf to Inf"
 
 # incorrectly-shaped weights errors
 
-    The first dimension of weights must be the number of distributions in the mixture (2)
-    However it was 1
+    Code
+      mixture(normal(0, 1), normal(0, 2), weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! The first dimension of weights must be the number of distributions in the mixture (2)
+      However it was 1
 
 # mixtures with insufficient distributions errors
 
-    `mixture()` must be passed at least 2 distributions
-    The number of distributions passed was: 1
+    Code
+      mixture(normal(0, 2), weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! `mixture()` must be passed at least 2 distributions
+      The number of distributions passed was: 1
 
 ---
 
-    `mixture()` must be passed at least 2 distributions
-    The number of distributions passed was: 0
+    Code
+      mixture(weights = weights)
+    Condition
+      Error in `initialize()`:
+      ! `mixture()` must be passed at least 2 distributions
+      The number of distributions passed was: 0
 

--- a/tests/testthat/_snaps/operators.md
+++ b/tests/testthat/_snaps/operators.md
@@ -1,13 +1,21 @@
 # %*% errors informatively
 
-    Incompatible dimensions: "3x4" vs "1x4"
+    Code
+      a %*% b
+    Condition
+      Error in `a %*% b`:
+      ! Incompatible dimensions: "3x4" vs "1x4"
 
 ---
 
-    Only two-dimensional <greta_array>s can be matrix-multiplied
-    Dimensions for each are:
-    `x`: "3x4"
-    `y`: "2x2x2"
+    Code
+      a %*% c
+    Condition
+      Error in `a %*% c`:
+      ! Only two-dimensional <greta_array>s can be matrix-multiplied
+      Dimensions for each are:
+      `x`: "3x4"
+      `y`: "2x2x2"
 
 # %*% works when one is a non-greta array
 

--- a/tests/testthat/_snaps/opt.md
+++ b/tests/testthat/_snaps/opt.md
@@ -25,56 +25,92 @@
 
 # opt fails with defunct optimisers
 
-    The optimiser, `powell()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = powell())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `powell()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `momentum()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = momentum())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `momentum()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `cg()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = cg())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `cg()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `newton_cg()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = newton_cg())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `newton_cg()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `l_bfgs_b()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = l_bfgs_b())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `l_bfgs_b()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `tnc()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = tnc())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `tnc()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `cobyla()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = cobyla())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `cobyla()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 ---
 
-    The optimiser, `slsqp()`, is defunct and has been removed in greta 0.5.0.
-    Please use a different optimiser.
-    See `?optimisers` for detail on which optimizers are removed.
+    Code
+      o <- opt(m, optimiser = slsqp())
+    Condition
+      Error in `optimiser_defunct_error()`:
+      ! The optimiser, `slsqp()`, is defunct and has been removed in greta 0.5.0.
+      Please use a different optimiser.
+      See `?optimisers` for detail on which optimizers are removed.
 
 # TF opt with `gradient_descent` fails with bad initial values
 
-    Detected numerical overflow during optimisation
-    Please try one of the following:
-    i Using different initial values
-    i Using another optimiser. (E.g., instead of `gradient_descent()`, try `adam()`)
+    Code
+      o <- opt(m, hessian = TRUE, optimiser = gradient_descent())
+    Condition
+      Error in `self$run_minimiser()`:
+      ! Detected numerical overflow during optimisation
+      Please try one of the following:
+      i Using different initial values
+      i Using another optimiser. (E.g., instead of `gradient_descent()`, try `adam()`)
 

--- a/tests/testthat/_snaps/simulate.md
+++ b/tests/testthat/_snaps/simulate.md
@@ -1,23 +1,43 @@
 # simulate errors if distribution-free variables are not fixed
 
-    the target <greta_array>s are related to variables that do not have distributions so cannot be sampled
+    Code
+      sims <- simulate(m)
+    Condition
+      Error in `calculate_list()`:
+      ! the target <greta_array>s are related to variables that do not have distributions so cannot be sampled
 
 # simulate errors if a distribution cannot be sampled from
 
-    Sampling is not yet implemented for "hypergeometric" distributions
+    Code
+      sims <- simulate(m)
+    Condition
+      Error in `check_sampling_implemented()`:
+      ! Sampling is not yet implemented for "hypergeometric" distributions
 
 # simulate errors nicely if nsim is invalid
 
-    nsim must be a positive integer
-    However the value provided was: 0
+    Code
+      simulate(m, nsim = 0)
+    Condition
+      Error:
+      ! nsim must be a positive integer
+      However the value provided was: 0
 
 ---
 
-    nsim must be a positive integer
-    However the value provided was: -1
+    Code
+      simulate(m, nsim = -1)
+    Condition
+      Error:
+      ! nsim must be a positive integer
+      However the value provided was: -1
 
 ---
 
-    nsim must be a positive integer
-    However the value provided was: NA
+    Code
+      simulate(m, nsim = "five")
+    Condition
+      Error:
+      ! nsim must be a positive integer
+      However the value provided was: NA
 

--- a/tests/testthat/_snaps/syntax.md
+++ b/tests/testthat/_snaps/syntax.md
@@ -1,39 +1,75 @@
 # `distribution<-` errors informatively
 
-    right hand side must be a <greta_array>
+    Code
+      distribution(y) <- x
+    Condition
+      Error in `distribution<-`:
+      ! right hand side must be a <greta_array>
 
 ---
 
-    right hand side must have a distribution
+    Code
+      distribution(y) <- as_data(x)
+    Condition
+      Error in `distribution<-`:
+      ! right hand side must have a distribution
 
 ---
 
-    right hand side must have a distribution
+    Code
+      distribution(y) <- variable()
+    Condition
+      Error in `distribution<-`:
+      ! right hand side must have a distribution
 
 ---
 
-    left and right hand sides have different dimensions.
-    The distribution must have dimension of either "3x3x2" or "1x1",but instead has dimension "3x3x1"
+    Code
+      distribution(y) <- normal(0, 1, dim = c(3, 3, 1))
+    Condition
+      Error in `distribution<-`:
+      ! left and right hand sides have different dimensions.
+      The distribution must have dimension of either "3x3x2" or "1x1",but instead has dimension "3x3x1"
 
 ---
 
-    left hand side already has a distribution assigned
+    Code
+      distribution(y_) <- normal(0, 1)
+    Condition
+      Error in `distribution<-`:
+      ! left hand side already has a distribution assigned
 
 ---
 
-    right hand side has already been assigned fixed values
+    Code
+      distribution(y2) <- y1
+    Condition
+      Error in `distribution<-`:
+      ! right hand side has already been assigned fixed values
 
 ---
 
-    distributions can only be assigned to data <greta array>s
+    Code
+      distribution(z) <- normal(0, 1)
+    Condition
+      Error in `distribution<-`:
+      ! distributions can only be assigned to data <greta array>s
 
 ---
 
-    distributions can only be assigned to data <greta array>s
+    Code
+      distribution(z2) <- normal(0, 1)
+    Condition
+      Error in `distribution<-`:
+      ! distributions can only be assigned to data <greta array>s
 
 ---
 
-    distributions can only be assigned to data <greta array>s
+    Code
+      distribution(z2) <- normal(0, 1)
+    Condition
+      Error in `distribution<-`:
+      ! distributions can only be assigned to data <greta array>s
 
 # distribution() errors informatively
 

--- a/tests/testthat/_snaps/transforms.md
+++ b/tests/testthat/_snaps/transforms.md
@@ -1,5 +1,9 @@
 # imultilogit errors informatively
 
-    `x must be two dimensional`
-    However, `x` has dimensions: 3x4x3
+    Code
+      imultilogit(x)
+    Condition
+      Error in `imultilogit()`:
+      ! `x must be two dimensional`
+      However, `x` has dimensions: 3x4x3
 

--- a/tests/testthat/_snaps/truncated.md
+++ b/tests/testthat/_snaps/truncated.md
@@ -1,11 +1,19 @@
 # bad truncations error
 
-    lower bound must be 0 or higher
-    lower bound is: -1
+    Code
+      lognormal(0, 1, truncation = c(-1, Inf))
+    Condition
+      Error in `initialize()`:
+      ! lower bound must be 0 or higher
+      lower bound is: -1
 
 ---
 
-    lower and upper bounds must be between 0 and 1
-    lower bound is: -1
-    upper bound is: 2
+    Code
+      beta(1, 1, truncation = c(-1, 2))
+    Condition
+      Error in `initialize()`:
+      ! lower and upper bounds must be between 0 and 1
+      lower bound is: -1
+      upper bound is: 2
 

--- a/tests/testthat/_snaps/variables.md
+++ b/tests/testthat/_snaps/variables.md
@@ -1,44 +1,68 @@
 # variable() errors informatively
 
-    lower and upper must be numeric
-    lower has class: numeric
-    lower has length: 1
-    upper has class: logical
-    upper has length: 1
+    Code
+      variable(upper = NA)
+    Condition
+      Error in `initialize()`:
+      ! lower and upper must be numeric
+      lower has class: numeric
+      lower has length: 1
+      upper has class: logical
+      upper has length: 1
 
 ---
 
-    lower and upper must be numeric
-    lower has class: numeric
-    lower has length: 1
-    upper has class: function
-    upper has length: 1
+    Code
+      variable(upper = head)
+    Condition
+      Error in `initialize()`:
+      ! lower and upper must be numeric
+      lower has class: numeric
+      lower has length: 1
+      upper has class: function
+      upper has length: 1
 
 ---
 
-    lower and upper must be numeric
-    lower has class: logical
-    lower has length: 1
-    upper has class: numeric
-    upper has length: 1
+    Code
+      variable(lower = NA)
+    Condition
+      Error in `initialize()`:
+      ! lower and upper must be numeric
+      lower has class: logical
+      lower has length: 1
+      upper has class: numeric
+      upper has length: 1
 
 ---
 
-    lower and upper must be numeric
-    lower has class: function
-    lower has length: 1
-    upper has class: numeric
-    upper has length: 1
+    Code
+      variable(lower = head)
+    Condition
+      Error in `initialize()`:
+      ! lower and upper must be numeric
+      lower has class: function
+      lower has length: 1
+      upper has class: numeric
+      upper has length: 1
 
 ---
 
-    incompatible dimensions: 3x1, 2x1
+    Code
+      variable(lower = 0:2, upper = 1:2)
+    Condition
+      Error in `initialize()`:
+      ! incompatible dimensions: 3x1, 2x1
 
 ---
 
-    upper bounds must be greater than lower bounds
-    lower is: 1
-    upper is: 1
+    Code
+      variable(lower = 1, upper = 1)
+    Condition
+      Error in `initialize()`:
+      ! upper bounds must be greater than lower bounds
+      lower is: 1
+      upper is: 1
 
 # constrained variable constructors error informatively
 

--- a/tests/testthat/test-zzzzzz.R
+++ b/tests/testthat/test-zzzzzz.R
@@ -10,7 +10,7 @@
 #     mockery::stub(check_tf_version, 'have_tf', FALSE)
 #     mockery::stub(check_tf_version, 'have_tfp', FALSE)
 #
-#     expect_snapshot_error(
+#     expect_snapshot(error = TRUE,
 #       check_tf_version("error")
 #       )
 #

--- a/tests/testthat/test_calculate.R
+++ b/tests/testthat/test_calculate.R
@@ -185,7 +185,7 @@ test_that("stochastic calculate works with greta_mcmc_list objects", {
   )
 
   # this should error without nsim being specified (y is stochastic)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_a <- calculate(a, y, values = draws)
   )
 
@@ -240,7 +240,7 @@ test_that("calculate errors if the mcmc samples unrelated to target", {
 
   c <- normal(0, 1)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_c <- calculate(c, values = draws)
   )
 })
@@ -270,7 +270,7 @@ test_that("stochastic calculate works with mcmc samples & new stochastics", {
 
   # this should error without nsim being specified (b is stochastic and not
   # given by draws)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_b <- calculate(b, values = draws)
   )
 
@@ -287,12 +287,12 @@ test_that("calculate errors nicely if non-greta arrays are passed", {
   y <- a * x
 
   # it should error nicely
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, x, values = list(x = c(2, 1)))
   )
 
   # and a hint for this common error
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, list(x = c(2, 1)))
   )
 
@@ -306,7 +306,7 @@ test_that("calculate errors nicely if values for stochastics not passed", {
   y <- a * x
 
   # it should error nicely
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, values = list(x = c(2, 1)))
   )
 
@@ -322,7 +322,7 @@ test_that("calculate errors nicely if values have incorrect dimensions", {
   y <- a * x
 
   # it should error nicely
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, values = list(a = c(1, 1)))
   )
 })
@@ -365,13 +365,13 @@ test_that("calculate errors nicely with invalid batch sizes", {
   draws <- mcmc(m, warmup = 0, n_samples = samples, verbose = FALSE)
 
   # variable valid batch sizes
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, values = draws, trace_batch_size = 0)
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, values = draws, trace_batch_size = NULL)
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_y <- calculate(y, values = draws, trace_batch_size = NA)
   )
 })
@@ -440,7 +440,7 @@ test_that("calculate errors if distribution-free variables are not fixed", {
   # fix variable
   a <- variable()
   y <- normal(a, 1)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_a <- calculate(a, y, nsim = 1)
   )
 })
@@ -450,7 +450,7 @@ test_that("calculate errors if a distribution cannot be sampled from", {
 
   # fix variable
   y <- hypergeometric(5, 3, 2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     sims <- calculate(y, nsim = 1)
   )
 })
@@ -460,15 +460,15 @@ test_that("calculate errors nicely if nsim is invalid", {
 
   x <- normal(0, 1)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_x <- calculate(x, nsim = 0)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_x <- calculate(x, nsim = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     calc_x <- calculate(x, nsim = "five")
   )
 })

--- a/tests/testthat/test_distributions.R
+++ b/tests/testthat/test_distributions.R
@@ -733,21 +733,21 @@ test_that("poisson() and binomial() error informatively in glm", {
   skip_if_not(check_tf_version())
 
   # if passed as an object
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     glm(1 ~ 1, family = poisson)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     glm(1 ~ 1, family = binomial)
   )
 
   # if executed alone
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     glm(1 ~ 1, family = poisson())
   )
 
   # if given a link
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     glm(1 ~ 1, family = poisson("sqrt"))
   )
 })
@@ -785,27 +785,27 @@ test_that("lkj_correlation distribution errors informatively", {
     "greta_array"
   ))
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lkj_correlation(-1, dim)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lkj_correlation(c(3, 3), dim)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lkj_correlation(uniform(0, 1, dim = 2), dim)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lkj_correlation(4, dimension = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lkj_correlation(4, dim = c(3, 3))
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lkj_correlation(4, dim = NA)
   )
 })
@@ -835,11 +835,11 @@ test_that("multivariate_normal distribution errors informatively", {
   ))
 
   # bad means
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_c, a)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_d, a)
   )
 
@@ -850,39 +850,39 @@ test_that("multivariate_normal distribution errors informatively", {
   ))
 
   # bad sigmas
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, b)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, c)
   )
 
   # mismatched parameters
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, d)
   )
 
   # scalars
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(0, 1)
   )
 
   # bad n_realisations
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, a, n_realisations = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, a, n_realisations = c(1, 3))
   )
 
   # bad dimension
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, a, dimension = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multivariate_normal(m_a, a, dimension = c(1, 3))
   )
 })
@@ -917,25 +917,25 @@ test_that("multinomial distribution errors informatively", {
   ))
 
   # scalars
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multinomial(c(1), 1)
   )
 
   # bad n_realisations
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multinomial(10, p_a, n_realisations = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multinomial(10, p_a, n_realisations = c(1, 3))
   )
 
   # bad dimension
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multinomial(10, p_a, dimension = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     multinomial(10, p_a, dimension = c(1, 3))
   )
 })
@@ -958,25 +958,25 @@ test_that("categorical distribution errors informatively", {
   ))
 
   # scalars
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     categorical(1),
   )
 
   # bad n_realisations
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     categorical(p_a, n_realisations = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     categorical(p_a, n_realisations = c(1, 3))
   )
 
   # bad dimension
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     categorical(p_a, dimension = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     categorical(p_a, dimension = c(1, 3))
   )
 })
@@ -1000,25 +1000,25 @@ test_that("dirichlet distribution errors informatively", {
   ))
 
   # scalars
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet(1),
   )
 
   # bad n_realisations
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet(alpha_a, n_realisations = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet(alpha_a, n_realisations = c(1, 3))
   )
 
   # bad dimension
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet(alpha_a, dimension = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet(alpha_a, dimension = c(1, 3))
   )
 })
@@ -1066,25 +1066,25 @@ test_that("dirichlet-multinomial distribution errors informatively", {
   ))
 
   # scalars
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet_multinomial(c(1), 1)
   )
 
   # bad n_realisations
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet_multinomial(10, alpha_a, n_realisations = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet_multinomial(10, alpha_a, n_realisations = c(1, 3))
   )
 
   # bad dimension
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet_multinomial(10, alpha_a, dimension = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dirichlet_multinomial(10, alpha_a, dimension = c(1, 3))
   )
 })

--- a/tests/testthat/test_extract_replace_combine.R
+++ b/tests/testthat/test_extract_replace_combine.R
@@ -388,11 +388,11 @@ test_that("abind errors informatively", {
   b <- ones(1, 1, 3)
   c <- ones(5, 1, 1)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     abind(a, b)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     abind(a, c, along = 5)
   )
 
@@ -425,7 +425,7 @@ test_that("assign errors on variable greta arrays", {
   skip_if_not(check_tf_version())
 
   z <- normal(0, 1, dim = 5)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     z[1] <- 3
   )
 })
@@ -436,11 +436,11 @@ test_that("rbind and cbind give informative error messages", {
   a <- as_data(randn(5, 1))
   b <- as_data(randn(1, 5))
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     rbind(a, b)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     cbind(a, b)
   )
 })
@@ -449,16 +449,16 @@ test_that("replacement gives informative error messages", {
   skip_if_not(check_tf_version())
 
   x <- ones(2, 2, 2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     x[1:2, , 1] <- seq_len(3)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     x[1, 1, 3] <- 1
   )
 
   x <- ones(2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     x[3] <- 1
   )
 })
@@ -467,12 +467,12 @@ test_that("extraction gives informative error messages", {
   skip_if_not(check_tf_version())
 
   x <- ones(2, 2, 2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     x[1, 1, 3]
   )
 
   x <- ones(2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     x[3]
   )
 })
@@ -603,19 +603,19 @@ test_that("dim<- errors as expected", {
 
   x <- zeros(3, 4)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dim(x) <- pi[0]
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dim(x) <- c(1, NA)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dim(x) <- c(1, -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     dim(x) <- 13
   )
 })

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -69,7 +69,7 @@ test_that("cummax and cummin functions error informatively", {
   x <- as_data(randn(10))
 
   for (fun in cumulative_funs) {
-    expect_snapshot_error(
+    expect_snapshot(error = TRUE,
       fun(x)
     )
   }
@@ -82,7 +82,7 @@ test_that("complex number functions error informatively", {
   x <- as_data(randn(25, 4))
 
   for (fun in complex_funs) {
-    expect_snapshot_error(
+    expect_snapshot(error = TRUE,
       fun(x)
     )
   }
@@ -244,19 +244,19 @@ test_that("cumulative functions error as expected", {
   b <- as_data(randn(5, 1, 1))
 
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     cumsum(a)
     )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     cumsum(b)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     cumprod(a)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     cumprod(b)
   )
 
@@ -384,19 +384,19 @@ test_that("colSums etc. error as expected", {
 
   x <- as_data(randn(3, 4, 5))
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     colSums(x, dims = 3)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     rowSums(x, dims = 3)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     colMeans(x, dims = 3)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     rowMeans(x, dims = 3)
   )
 
@@ -409,19 +409,19 @@ test_that("forwardsolve and backsolve error as expected", {
   b <- as_data(randn(5, 25))
   c <- chol(a)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     forwardsolve(a, b, k = 1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     backsolve(a, b, k = 1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     forwardsolve(a, b, transpose = TRUE)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     backsolve(a, b, transpose = TRUE)
   )
 
@@ -435,12 +435,12 @@ test_that("tapply errors as expected", {
   b <- ones(10, 2)
 
   # X must be a column vector
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     tapply(b, group, "sum")
   )
 
   # INDEX can't be a greta array
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     tapply(a, as_data(group), "sum")
   )
 })
@@ -495,7 +495,7 @@ test_that("ignored options are errored/warned about", {
   skip_if_not(check_tf_version())
 
   x <- ones(3, 3)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     round(x, 2)
   )
 
@@ -523,39 +523,39 @@ test_that("incorrect dimensions are errored about", {
   x <- ones(3, 3, 3)
   y <- ones(3, 4)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     t(x)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     aperm(x, 2:1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     chol(x)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     chol(y)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     chol2symm(x)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     chol2symm(y)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     eigen(x)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     eigen(y)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     rdist(x, y)
   )
 })

--- a/tests/testthat/test_future.R
+++ b/tests/testthat/test_future.R
@@ -41,7 +41,7 @@ test_that("mcmc errors for invalid parallel plans", {
   )
 
   future::plan(future::multicore)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     check_future_plan()
   )
 
@@ -49,7 +49,7 @@ test_that("mcmc errors for invalid parallel plans", {
   if (.Platform$OS.type != "windows"){
     cl <- parallel::makeCluster(2L, type = "FORK")
     future::plan(future::cluster, workers = cl)
-    expect_snapshot_error(
+    expect_snapshot(error = TRUE,
       check_future_plan()
     )
   }
@@ -89,13 +89,13 @@ test_that("mcmc errors for invalid parallel plans", {
   withr::defer(future::plan(op))
 
   future::plan(future::multicore)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, verbose = FALSE)
   )
 
   cl <- parallel::makeForkCluster(2L)
   future::plan(future::cluster, workers = cl)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, verbose = FALSE)
   )
 

--- a/tests/testthat/test_iid_samples.R
+++ b/tests/testthat/test_iid_samples.R
@@ -284,7 +284,7 @@ test_that("distributions without RNG error nicely", {
   skip_if_not(check_tf_version())
 
   # univariate
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     compare_iid_samples(hypergeometric,
                         rhyper,
                         parameters = list(m = 11, n = 8, k = 5)
@@ -292,7 +292,7 @@ test_that("distributions without RNG error nicely", {
   )
 
   # truncated RNG not implemented
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     compare_iid_samples(f,
       rtf,
       parameters = list(

--- a/tests/testthat/test_inference.R
+++ b/tests/testthat/test_inference.R
@@ -15,7 +15,7 @@ test_that("bad mcmc proposals are rejected", {
       )
     expect_match(out, "100% bad")
 
-    expect_snapshot_error(
+    expect_snapshot(error = TRUE,
       draws <- mcmc(m,
                     chains = 1,
                     n_samples = 2,
@@ -30,7 +30,7 @@ test_that("bad mcmc proposals are rejected", {
   z <- normal(-1e120, 1e-120)
   distribution(x) <- normal(z, 1e-120)
   m <- model(z, precision = "single")
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, n_samples = 1, warmup = 0, verbose = FALSE)
   )
 
@@ -119,7 +119,7 @@ test_that("mcmc handles initial values nicely", {
 
   # too many sets of initial values
   inits <- replicate(3, initials(z = rnorm(1)), simplify = FALSE)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     draws <- mcmc(m,
          warmup = 10, n_samples = 10, verbose = FALSE,
          chains = 2, initial_values = inits
@@ -128,7 +128,7 @@ test_that("mcmc handles initial values nicely", {
 
   # initial values have the wrong length
   inits <- replicate(2, initials(z = rnorm(2)), simplify = FALSE)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     draws <- mcmc(m,
          warmup = 10, n_samples = 10, verbose = FALSE,
          chains = 2, initial_values = inits
@@ -258,7 +258,7 @@ test_that("model errors nicely", {
   # model should give a nice error if passed something other than a greta array
   a <- 1
   b <- normal(0, a)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     model(a, b)
   )
 })
@@ -302,11 +302,11 @@ test_that("initials works", {
   skip_if_not(check_tf_version())
 
   # errors on bad objects
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     initials(a = FALSE)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     initials(FALSE)
   )
 
@@ -329,39 +329,39 @@ test_that("prep_initials errors informatively", {
   m <- model(z)
 
   # bad objects:
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, initial_values = FALSE, verbose = FALSE)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, initial_values = list(FALSE), verbose = FALSE)
   )
 
   # an unrelated greta array
   g <- normal(0, 1)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, initial_values = initials(g = 1), verbose = FALSE)
   )
 
   # non-variable greta arrays
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, initial_values = initials(f = 1), verbose = FALSE)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, initial_values = initials(z = 1), verbose = FALSE)
   )
 
   # out of bounds errors
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, initial_values = initials(b = -1), verbose = FALSE)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, initial_values = initials(d = -1), verbose = FALSE)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mcmc(m, chains = 1, initial_values = initials(e = 2), verbose = FALSE)
   )
 })

--- a/tests/testthat/test_install_greta_deps.R
+++ b/tests/testthat/test_install_greta_deps.R
@@ -1,13 +1,13 @@
 test_that("install_greta_deps errors appropriately", {
   skip_if_not(check_tf_version())
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     install_greta_deps(timeout = 0.001)
   )
 })
 
 # test_that("reinstall_greta_deps errors appropriately", {
 #   skip_if_not(check_tf_version())
-#   expect_snapshot_error(
+#   expect_snapshot(error = TRUE,
 #     reinstall_greta_deps(timeout = 0.001)
 #   )
 # })

--- a/tests/testthat/test_joint.R
+++ b/tests/testthat/test_joint.R
@@ -78,7 +78,7 @@ test_that("fixed discrete joint distributions can be sampled from", {
 test_that("joint of fixed and continuous distributions errors", {
   skip_if_not(check_tf_version())
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     joint(
       bernoulli(0.5),
       normal(0, 1)
@@ -89,11 +89,11 @@ test_that("joint of fixed and continuous distributions errors", {
 test_that("joint with insufficient distributions errors", {
   skip_if_not(check_tf_version())
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     joint(normal(0, 2))
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     joint()
   )
 })
@@ -101,7 +101,7 @@ test_that("joint with insufficient distributions errors", {
 test_that("joint with non-scalar distributions errors", {
   skip_if_not(check_tf_version())
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     joint(
       normal(0, 2, dim = 3),
       normal(0, 1, dim = 3)

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -5,7 +5,7 @@ test_that("check_tf_version works", {
   true_version <- tf$`__version__`
   tf$`__version__` <- "0.9.0" # nolint
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     check_tf_version("error")
   )
   expect_snapshot_warning(
@@ -69,26 +69,26 @@ test_that("define and mcmc error informatively", {
   x <- as_data(randn(10))
 
   # no model with non-probability density greta arrays
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     model(variable())
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     model(x)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     model()
   )
 
   # can't define a model for an unfixed discrete variable
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     model(bernoulli(0.5))
   )
 
   # no parameters here, so define or dag should error
   distribution(x) <- normal(0, 1)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     model(x)
   )
 
@@ -108,7 +108,7 @@ test_that("define and mcmc error informatively", {
   # can't draw samples of a data greta array
   z <- normal(x, 1)
   m <- model(x, z)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     draws <- mcmc(m, verbose = FALSE)
   )
 })
@@ -142,7 +142,7 @@ test_that("check_dims errors informatively", {
   )
 
   # with two differently shaped arrays it shouldn't
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     greta:::check_dims(a, c)
   )
 
@@ -165,14 +165,14 @@ test_that("disjoint graphs are checked", {
   # c is unrelated and has no density
   c <- variable()
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     m <- model(a, b, c)
   )
 
   # d is unrelated and known
   d <- as_data(randn(3))
   distribution(d) <- normal(0, 1)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     m <- model(a, b, d)
   )
 
@@ -220,7 +220,7 @@ test_that("cleanly() handles TF errors nicely", {
 
   expect_s3_class(cleanly(inversion_stop()), "error")
   expect_s3_class(cleanly(cholesky_stop()), "error")
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     cleanly(other_stop())
   )
 

--- a/tests/testthat/test_mixture.R
+++ b/tests/testthat/test_mixture.R
@@ -43,7 +43,7 @@ test_that("mixtures of fixed and continuous distributions errors", {
   skip_if_not(check_tf_version())
 
   weights <- uniform(0, 1, dim = 2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(
       bernoulli(0.5),
       normal(0, 1),
@@ -56,7 +56,7 @@ test_that("mixtures of multivariate and univariate errors", {
   skip_if_not(check_tf_version())
 
   weights <- uniform(0, 1, dim = 2)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(
       multivariate_normal(zeros(1, 3), diag(3)),
       normal(0, 1, dim = c(1, 3)),
@@ -71,7 +71,7 @@ test_that("mixtures of supports errors", {
   weights <- c(0.5, 0.5)
 
   # due to truncation
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(
       normal(0, 1, truncation = c(0, Inf)),
       normal(0, 1),
@@ -80,7 +80,7 @@ test_that("mixtures of supports errors", {
   )
 
   # due to bounds
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(
       lognormal(0, 1),
       normal(0, 1),
@@ -93,7 +93,7 @@ test_that("incorrectly-shaped weights errors", {
   skip_if_not(check_tf_version())
 
   weights <- uniform(0, 1, dim = c(1, 2))
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(
       normal(0, 1),
       normal(0, 2),
@@ -107,14 +107,14 @@ test_that("mixtures with insufficient distributions errors", {
 
   weights <- uniform(0, 1)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(
       normal(0, 2),
       weights = weights
     )
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     mixture(weights = weights)
   )
 

--- a/tests/testthat/test_operators.R
+++ b/tests/testthat/test_operators.R
@@ -99,11 +99,11 @@ test_that("%*% errors informatively", {
   b <- ones(1, 4)
   c <- ones(2, 2, 2)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     a %*% b
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     a %*% c
   )
 })

--- a/tests/testthat/test_opt.R
+++ b/tests/testthat/test_opt.R
@@ -86,14 +86,14 @@ test_that("opt fails with defunct optimisers", {
   m <- model(z)
 
   # check that the right ones error about defunct
-  expect_snapshot_error(o <- opt(m, optimiser = powell()))
-  expect_snapshot_error(o <- opt(m, optimiser = momentum()))
-  expect_snapshot_error(o <- opt(m, optimiser = cg()))
-  expect_snapshot_error(o <- opt(m, optimiser = newton_cg()))
-  expect_snapshot_error(o <- opt(m, optimiser = l_bfgs_b()))
-  expect_snapshot_error(o <- opt(m, optimiser = tnc()))
-  expect_snapshot_error(o <- opt(m, optimiser = cobyla()))
-  expect_snapshot_error(o <- opt(m, optimiser = slsqp()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = powell()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = momentum()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = cg()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = newton_cg()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = l_bfgs_b()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = tnc()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = cobyla()))
+  expect_snapshot(error = TRUE,o <- opt(m, optimiser = slsqp()))
 })
 
 test_that("opt accepts initial values for TF optimisers", {
@@ -190,7 +190,7 @@ test_that("TF opt with `gradient_descent` fails with bad initial values", {
   distribution(x) <- normal(z, sd)
 
   m <- model(z)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     o <- opt(m, hessian = TRUE, optimiser = gradient_descent())
   )
 

--- a/tests/testthat/test_simulate.R
+++ b/tests/testthat/test_simulate.R
@@ -24,7 +24,7 @@ test_that("simulate errors if distribution-free variables are not fixed", {
   a <- variable()
   y <- normal(a, 1)
   m <- model(y)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     sims <- simulate(m)
   )
 })
@@ -39,7 +39,7 @@ test_that("simulate errors if a distribution cannot be sampled from", {
   m <- lognormal(0, 1)
   distribution(y) <- hypergeometric(m, 3, 2)
   m <- model(y)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     sims <- simulate(m)
   )
 })
@@ -51,15 +51,15 @@ test_that("simulate errors nicely if nsim is invalid", {
   x <- normal(0, 1)
   m <- model(x)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     simulate(m, nsim = 0)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     simulate(m, nsim = -1)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     simulate(m, nsim = "five")
   )
 })

--- a/tests/testthat/test_syntax.R
+++ b/tests/testthat/test_syntax.R
@@ -36,28 +36,28 @@ test_that("`distribution<-` errors informatively", {
   x <- randn(1)
 
   # not a greta array with a distribution on the right
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(y) <- x
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(y) <- as_data(x)
   )
 
   # no density on the right
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(y) <- variable()
   )
 
   # non-scalar and wrong dimensions
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(y) <- normal(0, 1, dim = c(3, 3, 1))
   )
 
   # double assignment of distribution to node
   y_ <- as_data(y)
   distribution(y_) <- normal(0, 1)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(y_) <- normal(0, 1)
   )
 
@@ -66,25 +66,25 @@ test_that("`distribution<-` errors informatively", {
   y2 <- as_data(y)
   d <- normal(0, 1)
   distribution(y1) <- d
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(y2) <- y1
   )
 
   # assignment to a variable
   z <- variable()
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(z) <- normal(0, 1)
   )
 
   # assignment to an op
   z2 <- z^2
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(z2) <- normal(0, 1)
   )
 
   # assignment to another distribution
   u <- uniform(0, 1)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     distribution(z2) <- normal(0, 1)
   )
 

--- a/tests/testthat/test_transforms.R
+++ b/tests/testthat/test_transforms.R
@@ -31,7 +31,7 @@ test_that("imultilogit errors informatively", {
 
   x <- ones(3, 4, 3)
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     imultilogit(x)
   )
 

--- a/tests/testthat/test_truncated.R
+++ b/tests/testthat/test_truncated.R
@@ -623,11 +623,11 @@ test_that("truncated chi squared has correct densities", {
 test_that("bad truncations error", {
   skip_if_not(check_tf_version())
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     lognormal(0, 1, truncation = c(-1, Inf))
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     beta(1, 1, truncation = c(-1, 2))
   )
 })

--- a/tests/testthat/test_variables.R
+++ b/tests/testthat/test_variables.R
@@ -2,29 +2,29 @@ test_that("variable() errors informatively", {
   skip_if_not(check_tf_version())
 
   # bad types
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     variable(upper = NA)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     variable(upper = head)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     variable(lower = NA)
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     variable(lower = head)
   )
 
   # good types, bad values
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     variable(lower = 0:2, upper = 1:2)
   )
 
   # lower not below upper
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     variable(lower = 1, upper = 1)
   )
 })


### PR DESCRIPTION
This captures more information about the code that was run for the error, making it easier to debug/explore changes in snapshots.

Resolves #693 