### PR TITLE
* Improved `write_greta_install_log()` and `read_greta_install_log()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     reticulate (>= 1.19.0),
     rlang,
     tensorflow (>= 2.8.0),
+    tools,
     utils,
     whisker,
     yesno

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@ This release provides a few improvements to installation in greta. It should now
 * remove `greta_nodes_install/conda_*()` options as #493 makes them defunct.
 * Added option to write to a single logfile with `greta_set_install_logfile()`, and `write_greta_install_log()`, and `read_greta_install_log()` (#493)
 * Added `destroy_greta_deps()` function to remove miniconda and python conda environment
+* Improved `write_greta_install_log()` and `read_greta_install_log()` to use `tools::R_user_dir()` to always write to a file location. `read_greta_install_log()` will open one found from an environment variable or go to the default location. (#703)
 
 ## Minor
 

--- a/R/install_greta_deps.R
+++ b/R/install_greta_deps.R
@@ -9,9 +9,11 @@
 #'     `Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')`. Or use
 #'     [greta_set_install_logfile()] to set the path, e.g.,
 #'     `greta_set_install_logfile('path/to/logfile.html')`. By default it uses
-#'     `tools::R_user_dir("greta")`. To see installation notes or errors, after
-#'     installation you can open the logfile with [read_greta_install_log()],
-#'     or you can navigate to the logfile and open it in a browser.
+#'     `tools::R_user_dir("greta")` as the directory to save a logfile named
+#'     "greta-installation-logfile.html". To see installation notes or errors,
+#'     after installation you can open the logfile with
+#'     [read_greta_install_log()], or you can navigate to the logfile and open
+#'     it in a browser.
 #'
 #' @param deps object created with [greta_deps_spec()] where you
 #'   specify python, TF, and TFP versions. By default these are TF 2.15.0,
@@ -134,10 +136,7 @@ get_pkg_user_dir <- function() {
 
 greta_default_logfile <- function(){
   greta_user_dir <- get_pkg_user_dir()
-  default_greta_logfile_path <- glue::glue(
-    "{greta_user_dir}/greta-installation-logfile.html"
-  )
-  default_greta_logfile_path
+  file.path(greta_user_dir, "greta-installation-logfile.html")
 }
 
 

--- a/R/install_greta_deps.R
+++ b/R/install_greta_deps.R
@@ -4,15 +4,14 @@
 #'   these are TF 2.15.0, TFP 0.23.0, and Python 3.10. These Python modules
 #'   will be installed into a conda environment named "greta-env-tf2".
 #'
-#'   To see installation notes or errors, there isn't an argument to specify,
-#'     instead you will need to specify and environment variable,
-#'     `GRETA_INSTALLATION_LOG`, with
+#'   You can specify an environment variable to write a logfile to a specific
+#'     location with `GRETA_INSTALLATION_LOG` using
 #'     `Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')`. Or use
 #'     [greta_set_install_logfile()] to set the path, e.g.,
-#'     `greta_set_install_logfile('path/to/logfile.html')`. You can also skip
-#'     the restarting of R and use [write_greta_install_log()]. If you have
-#'     not specified the `GRETA_INSTALLATION_LOG` environmental variable, the
-#'     installation notes will indicate how to use [write_greta_install_log()].
+#'     `greta_set_install_logfile('path/to/logfile.html')`. By default it uses
+#'     `tools::R_user_dir("greta")`. To see installation notes or errors, after
+#'     installation you can open the logfile with [read_greta_install_log()],
+#'     or you can navigate to the logfile and open it in a browser.
 #'
 #' @param deps object created with [greta_deps_spec()] where you
 #'   specify python, TF, and TFP versions. By default these are TF 2.15.0,
@@ -111,28 +110,11 @@ install_greta_deps <- function(deps = greta_deps_spec(),
   # `reinstall_greta_deps()`
   # perhaps even stopping the session with a "yesno"
 
-  greta_logfile <- Sys.getenv("GRETA_INSTALLATION_LOG")
+  greta_logfile <- sys_get_env("GRETA_INSTALLATION_LOG")
 
-  logfile_exists <- nzchar(greta_logfile)
+  greta_logfile <- greta_logfile %||% greta_default_logfile()
 
-  no_logfile <- !logfile_exists
-
-
-  if (logfile_exists) {
-    write_greta_install_log(path = greta_logfile)
-  }
-
-  if (no_logfile) {
-    cli::cli_alert_warning(
-      text = c(
-        "No logfile specified. If you want to save the logfile to see any \\
-        install notes, or potential errors, you will need to \\
-        {.strong not restart R}, then run:\n\n",
-      "{.run write_greta_install_log('greta-logfile.html')}"
-      ),
-      wrap = TRUE
-    )
-  }
+  write_greta_install_log(path = greta_logfile)
 
   cli::cli_alert_success("Installation of {.pkg greta} dependencies \\
                          is complete!",
@@ -140,6 +122,22 @@ install_greta_deps <- function(deps = greta_deps_spec(),
 
   restart_or_not(restart)
 
+}
+
+get_pkg_user_dir <- function() {
+  pkg_user_dir <- tools::R_user_dir("greta")
+  if (!dir.exists(pkg_user_dir)) {
+    dir.create(pkg_user_dir, recursive = TRUE)
+  }
+  pkg_user_dir
+}
+
+greta_default_logfile <- function(){
+  greta_user_dir <- get_pkg_user_dir()
+  default_greta_logfile_path <- glue::glue(
+    "{greta_user_dir}/greta-installation-logfile.html"
+  )
+  default_greta_logfile_path
 }
 
 

--- a/R/write-logfiles.R
+++ b/R/write-logfiles.R
@@ -30,7 +30,7 @@ write_greta_install_log <- function(path = greta_logfile) {
     )
 
   cli::cli_progress_step(
-    msg = "Open with: {.fun read_greta_logfile}"
+    msg = "Open with: {.run read_greta_logfile()}"
   )
 
   template <- '
@@ -142,10 +142,9 @@ sys_get_env <- function(envvar){
 #' Read a greta logfile
 #'
 #' This is a convenience function to facilitate reading logfiles. It opens
-#'   a browser using [utils::browseURL()].
-#'
-#' @param path file to read. Optional. If not specified, it will search for
-#'   the environment variable "GRETA_INSTALLATION_LOG". To set
+#'   a browser using [utils::browseURL()]. It will search for
+#'   the environment variable "GRETA_INSTALLATION_LOG" or default to
+#'   `tools::R_user_dir("greta")`. To set
 #'   "GRETA_INSTALLATION_LOG" you can use
 #'   `Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')`. Or use
 #'   [greta_set_install_logfile()] to set the path, e.g.,
@@ -153,11 +152,12 @@ sys_get_env <- function(envvar){
 #'
 #' @return opens a URL in your default browser
 #' @export
-read_greta_install_log <- function(path = NULL){
-  log_env <- sys_get_env("GRETA_INSTALLATION_LOG")
+read_greta_install_log <- function(){
 
-  path <- path %||% log_env
+  greta_logfile <- sys_get_env("GRETA_INSTALLATION_LOG")
 
-  utils::browseURL(path)
+  greta_logfile <- greta_logfile %||% greta_default_logfile()
+
+  utils::browseURL(greta_logfile)
 
 }

--- a/R/write-logfiles.R
+++ b/R/write-logfiles.R
@@ -30,7 +30,7 @@ write_greta_install_log <- function(path = greta_logfile) {
     )
 
   cli::cli_progress_step(
-    msg = "Open with: {.run read_greta_logfile()}"
+    msg = "Open with: {.run read_greta_install_log()}"
   )
 
   template <- '

--- a/man/install_greta_deps.Rd
+++ b/man/install_greta_deps.Rd
@@ -49,9 +49,11 @@ location with \code{GRETA_INSTALLATION_LOG} using
 \code{Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')}. Or use
 \code{\link[=greta_set_install_logfile]{greta_set_install_logfile()}} to set the path, e.g.,
 \code{greta_set_install_logfile('path/to/logfile.html')}. By default it uses
-\code{tools::R_user_dir("greta")}. To see installation notes or errors, after
-installation you can open the logfile with \code{\link[=read_greta_install_log]{read_greta_install_log()}},
-or you can navigate to the logfile and open it in a browser.
+\code{tools::R_user_dir("greta")} as the directory to save a logfile named
+"greta-installation-logfile.html". To see installation notes or errors,
+after installation you can open the logfile with
+\code{\link[=read_greta_install_log]{read_greta_install_log()}}, or you can navigate to the logfile and open
+it in a browser.
 
 By default, if using RStudio, it will now ask you if you want to restart
 the R session. If the session is not interactive, or is not in RStudio,

--- a/man/install_greta_deps.Rd
+++ b/man/install_greta_deps.Rd
@@ -44,15 +44,14 @@ these are TF 2.15.0, TFP 0.23.0, and Python 3.10. These Python modules
 will be installed into a conda environment named "greta-env-tf2".
 }
 \details{
-To see installation notes or errors, there isn't an argument to specify,
-instead you will need to specify and environment variable,
-\code{GRETA_INSTALLATION_LOG}, with
+You can specify an environment variable to write a logfile to a specific
+location with \code{GRETA_INSTALLATION_LOG} using
 \code{Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')}. Or use
 \code{\link[=greta_set_install_logfile]{greta_set_install_logfile()}} to set the path, e.g.,
-\code{greta_set_install_logfile('path/to/logfile.html')}. You can also skip
-the restarting of R and use \code{\link[=write_greta_install_log]{write_greta_install_log()}}. If you have
-not specified the \code{GRETA_INSTALLATION_LOG} environmental variable, the
-installation notes will indicate how to use \code{\link[=write_greta_install_log]{write_greta_install_log()}}.
+\code{greta_set_install_logfile('path/to/logfile.html')}. By default it uses
+\code{tools::R_user_dir("greta")}. To see installation notes or errors, after
+installation you can open the logfile with \code{\link[=read_greta_install_log]{read_greta_install_log()}},
+or you can navigate to the logfile and open it in a browser.
 
 By default, if using RStudio, it will now ask you if you want to restart
 the R session. If the session is not interactive, or is not in RStudio,

--- a/man/read_greta_install_log.Rd
+++ b/man/read_greta_install_log.Rd
@@ -4,20 +4,18 @@
 \alias{read_greta_install_log}
 \title{Read a greta logfile}
 \usage{
-read_greta_install_log(path = NULL)
-}
-\arguments{
-\item{path}{file to read. Optional. If not specified, it will search for
-the environment variable "GRETA_INSTALLATION_LOG". To set
-"GRETA_INSTALLATION_LOG" you can use
-\code{Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')}. Or use
-\code{\link[=greta_set_install_logfile]{greta_set_install_logfile()}} to set the path, e.g.,
-\code{greta_set_install_logfile('path/to/logfile.html')}.}
+read_greta_install_log()
 }
 \value{
 opens a URL in your default browser
 }
 \description{
 This is a convenience function to facilitate reading logfiles. It opens
-a browser using \code{\link[utils:browseURL]{utils::browseURL()}}.
+a browser using \code{\link[utils:browseURL]{utils::browseURL()}}. It will search for
+the environment variable "GRETA_INSTALLATION_LOG" or default to
+\code{tools::R_user_dir("greta")}. To set
+"GRETA_INSTALLATION_LOG" you can use
+\code{Sys.setenv('GRETA_INSTALLATION_LOG'='path/to/logfile.html')}. Or use
+\code{\link[=greta_set_install_logfile]{greta_set_install_logfile()}} to set the path, e.g.,
+\code{greta_set_install_logfile('path/to/logfile.html')}.
 }


### PR DESCRIPTION
Use `tools::R_user_dir()` to always write to a file location. `read_greta_install_log()` will open one found from an environment variable or go to the default location. (#703)

Thanks @maelle for this excellent suggestion!