### PR TITLE
Addresses bad log prob samples in Wishart

### DIFF
--- a/R/greta_stash.R
+++ b/R/greta_stash.R
@@ -28,5 +28,6 @@ greta_stash$tf_num_error <- greta_note_msg
 #' greta_notes_tf_error()
 #' }
 greta_notes_tf_num_error <- function() {
-  cat(greta_stash$tf_num_error)
+  # wrap in paste0 to remove list properties
+  cat(paste0(greta_stash$tf_num_error))
 }

--- a/R/tf_functions.R
+++ b/R/tf_functions.R
@@ -703,8 +703,15 @@ tf_correlation_cholesky_bijector <- function() {
 }
 
 tf_covariance_cholesky_bijector <- function() {
-  tfp$bijectors$FillTriangular(upper = TRUE)
+
+  steps <- list(
+    tfp$bijectors$Transpose(perm = 1:0),
+    tfp$bijectors$FillScaleTriL(diag_shift = fl(1e-5))
+  )
+
+  tfp$bijectors$Chain(steps)
 }
+
 
 tf_simplex_bijector <- function(dim) {
   n_dim <- length(dim)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -855,7 +855,7 @@ check_samples <- function(
     model = m,
     sampler = sampler,
     n_effective = n_effective,
-    verbose = FALSE,
+    verbose = TRUE,
     one_by_one = one_by_one,
     time_limit = time_limit
   )
@@ -878,10 +878,20 @@ check_samples <- function(
   # suppressWarnings(stat <- ks.test(mcmc_samples, iid_samples))
   # testthat::expect_gte(stat$p.value, 0.01)
 
+  get_distribution_name <- function(x){
+    x_node <- get_node(x)
+    if (inherits(x_node, "operation_node")){
+      dist_name <- x_node$parents[[1]]$distribution$distribution_name
+    } else {
+      dist_name <- get_node(x)$distribution$distribution_name
+    }
+    dist_name
+  }
+
   list(
     mcmc_samples = mcmc_samples,
     iid_samples = iid_samples,
-    distrib = get_node(x)$distribution$distribution_name,
+    distrib = get_distribution_name(x),
     sampler_name = class(sampler)[1]
   )
 }

--- a/tests/testthat/test-lkj-log-prob-works.R
+++ b/tests/testthat/test-lkj-log-prob-works.R
@@ -1,15 +1,9 @@
-test_that("Wishart log_prob function does not return NaNs", {
-  sigma <- matrix(
-    data = c(1.2, 0.7, 0.7, 2.3),
-    nrow = 2,
-    ncol = 2
-  )
-  df <- 4
-  x <- wishart(df, sigma)[1, 2]
+test_that("LKJ distribution log_prob function does not return NaNs", {
+  x <- lkj_correlation(3, 2)[1, 2]
   m <- model(x)
   new_log_prob <- m$dag$generate_log_prob_function()
   m$dag$define_tf_log_prob_function()
-  prob_input <- matrix(rnorm(12), 4, 3)
+  prob_input <- matrix(rnorm(4), 4, 1)
   log_probs <- new_log_prob(prob_input)
 
   is_nan_adjusted <- all(is.nan(as.numeric(log_probs$adjusted)))

--- a/tests/testthat/test-wishart-log-prob-works.R
+++ b/tests/testthat/test-wishart-log-prob-works.R
@@ -1,0 +1,19 @@
+test_that("Wishart log_prob function", {
+  sigma <- matrix(
+    data = c(1.2, 0.7, 0.7, 2.3),
+    nrow = 2,
+    ncol = 2
+  )
+  df <- 4
+  x <- wishart(df, sigma)[1, 2]
+  m <- model(x)
+  new_log_prob <- m$dag$generate_log_prob_function()
+  m$dag$define_tf_log_prob_function()
+  prob_input <- matrix(rnorm(12), 4, 3) # this gives us `x_chol` with nan...
+  log_probs <- new_log_prob(prob_input)
+
+  is_nan_adjusted <- all(is.nan(as.numeric(log_probs$adjusted)))
+  is_nan_unadjusted <- all(is.nan(as.numeric(log_probs$unadjusted)))
+
+  expect_false(is_nan_adjusted && is_nan_unadjusted)
+})


### PR DESCRIPTION
* Uses `tfp$bijectors$FillScaleTriL` instead of `tfp$bijectors$FillTriangular`
* Apples Chaining to ensure input is transposed
* Related to #729 