### PR TITLE
Restructure of hierarchy of R6 classes, tune_tf and tune_r

### DIFF
--- a/R/samplers.R
+++ b/R/samplers.R
@@ -120,10 +120,31 @@ print.sampler <- function(x, ...) {
   cat(msg)
 }
 
+tune_tf <- R6Class(
+  "tune_tf",
+  inherit = sampler,
+  public = list(
+    parameters = list(),
+    accept_target = NULL,
+    define_tf_kernel = NULL,
+    sampler_parameter_values = NULL
+  )
+)
+
+tune_r <- R6Class(
+  "tune_r",
+  inherit = sampler,
+  public = list(
+    parameters = list(),
+    accept_target = NULL,
+    define_tf_kernel = NULL,
+    sampler_parameter_values = NULL
+  )
+)
 
 hmc_sampler <- R6Class(
   "hmc_sampler",
-  inherit = sampler,
+  inherit = tune_r,
   public = list(
     parameters = list(
       Lmin = 10,
@@ -191,7 +212,7 @@ hmc_sampler <- R6Class(
 
 rwmh_sampler <- R6Class(
   "rwmh_sampler",
-  inherit = sampler,
+  inherit = tune_r,
   public = list(
     parameters = list(
       proposal = "normal",
@@ -268,7 +289,7 @@ rwmh_sampler <- R6Class(
 
 slice_sampler <- R6Class(
   "slice_sampler",
-  inherit = sampler,
+  inherit = tune_r,
   public = list(
     parameters = list(
       max_doublings = NA

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -122,24 +122,12 @@ print.sampler <- function(x, ...) {
 
 tune_tf <- R6Class(
   "tune_tf",
-  inherit = sampler,
-  public = list(
-    parameters = list(),
-    accept_target = NULL,
-    define_tf_kernel = NULL,
-    sampler_parameter_values = NULL
-  )
+  inherit = sampler
 )
 
 tune_r <- R6Class(
   "tune_r",
-  inherit = sampler,
-  public = list(
-    parameters = list(),
-    accept_target = NULL,
-    define_tf_kernel = NULL,
-    sampler_parameter_values = NULL
-  )
+  inherit = sampler
 )
 
 hmc_sampler <- R6Class(


### PR DESCRIPTION
Resolves #775 - tries to do:

old:
- inference --> sampler --> hmc_sampler / slice_sampler / rwmh_sampler / adaptive_hmc_sampler

new:

- inference --> sampler --> tune_r --> hmc_sampler / slice_sampler / rwmh_sampler
- inference --> sampler --> tune_tf --> adaptive_hmc_sampler / ...