### PR TITLE
improve check_2d/multivariate error messages

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -148,14 +148,19 @@ check_dims <- function(..., target_dim = NULL, call = rlang::caller_env()) {
 }
 
 # make sure a greta array is 2D
-check_2d_multivariate <- function(x, call = rlang::caller_env()) {
+check_2d_multivariate <- function(
+  x,
+  call = rlang::caller_env(),
+  arg = rlang::caller_arg(x)
+) {
+  check_1d(x)
   if (!is_2d(x)) {
     cli::cli_abort(
       message = c(
         "Dimensions of parameters not compatible with multivariate \\
-        distribution parameters of multivariate distributions cannot have \\
-        more than two dimensions",
-        "object {.var x} has dimensions: {paste(dim(x), collapse = 'x')}"
+        distribution parameters",
+        "Multivariate distributions cannot have more than two dimensions",
+        "Object {.arg {arg}} has dimensions: {paste(dim(x), collapse = 'x')}"
       ),
       call = call
     )
@@ -1084,6 +1089,27 @@ check_if_model_info <- function(
   }
 }
 
+is_1d <- function(x) {
+  is.null(dim(x)) && (length(x) == 1)
+}
+
+check_1d <- function(
+  x,
+  arg = rlang::caller_arg(x),
+  call = rlang::caller_env()
+) {
+  if (is_1d(x)) {
+    cli::cli_abort(
+      message = c(
+        "{.arg {arg}} must be two dimensional",
+        "However, {.arg {arg}} is one dimensional and contains the value: \\
+        {.value {x}}"
+      ),
+      call = call
+    )
+  }
+}
+
 check_2d <- function(
   x,
   arg = rlang::caller_arg(x),
@@ -1092,7 +1118,7 @@ check_2d <- function(
   if (!is_2d(x)) {
     cli::cli_abort(
       message = c(
-        "{.arg {arg} must be two dimensional}",
+        "{.arg {arg}} must be two dimensional",
         "However, {.arg {arg}} has dimensions: {paste(dim(x), collapse = 'x')}"
       ),
       call = call

--- a/R/utils.R
+++ b/R/utils.R
@@ -905,6 +905,7 @@ message_if_using_gpu <- function(compute_options) {
 }
 
 n_dim <- function(x) length(dim(x))
+
 is_2d <- function(x) n_dim(x) == 2
 
 is.node <- function(x, ...) {

--- a/tests/testthat/_snaps/distributions.md
+++ b/tests/testthat/_snaps/distributions.md
@@ -189,8 +189,9 @@
       multivariate_normal(m_a, b)
     Condition
       Error in `lapply()`:
-      ! Dimensions of parameters not compatible with multivariate distribution parameters of multivariate distributions cannot have more than two dimensions
-      object `x` has dimensions: 3x3x3
+      ! Dimensions of parameters not compatible with multivariate distribution parameters
+      Multivariate distributions cannot have more than two dimensions
+      Object `X[[i]]` has dimensions: 3x3x3
 
 ---
 

--- a/tests/testthat/_snaps/functions.md
+++ b/tests/testthat/_snaps/functions.md
@@ -134,7 +134,7 @@
       solve(b, a)
     Condition
       Error in `solve()`:
-      ! `a must be two dimensional`
+      ! `a` must be two dimensional
       However, `a` has dimensions: 5x25x2
 
 ---
@@ -143,7 +143,7 @@
       solve(c, b)
     Condition
       Error in `solve()`:
-      ! `b must be two dimensional`
+      ! `b` must be two dimensional
       However, `b` has dimensions: 5x25x2
 
 ---
@@ -179,7 +179,7 @@
       sweep(b, 1, stats)
     Condition
       Error in `sweep()`:
-      ! `x must be two dimensional`
+      ! `x` must be two dimensional
       However, `x` has dimensions: 5x25x2
 
 ---
@@ -223,7 +223,7 @@
       kronecker(a, b)
     Condition
       Error in `kronecker()`:
-      ! `Y must be two dimensional`
+      ! `Y` must be two dimensional
       However, `Y` has dimensions: 5x25x2
 
 ---
@@ -232,7 +232,7 @@
       kronecker(b, c)
     Condition
       Error in `kronecker()`:
-      ! `X must be two dimensional`
+      ! `X` must be two dimensional
       However, `X` has dimensions: 5x25x2
 
 # colSums etc. error as expected

--- a/tests/testthat/_snaps/greta-sitrep.md
+++ b/tests/testthat/_snaps/greta-sitrep.md
@@ -246,18 +246,18 @@
     Message
       
       -- R ---------------------------------------------------------------------------
-      * version: 4.4.2
+      * version: 4.5.0
       * path: '/Library/Frameworks/R.framework/Resources'
       
       -- greta -----------------------------------------------------------------------
       * version: 0.5.0.9000
-      * path: '/Users/nick/github/greta-dev/greta'
+      * path: '/Users/nick_1/github/greta-dev/greta'
       
       -- python ----------------------------------------------------------------------
       i checking if python available
       v python (v3.10) available
       
-      * path: '/Users/nick/Library/r-miniconda-arm64'
+      * path: '/Users/nick_1/Library/r-miniconda-arm64'
       
       -- greta conda environment -----------------------------------------------------
       i checking if greta conda environment available
@@ -269,7 +269,7 @@
       i checking if TensorFlow available
       v TensorFlow (v2.15.0) available
       
-      * R path: '/Users/nick/Library/R/arm64/4.4/library/tensorflow'
+      * R path: '/Users/nick_1/Library/R/arm64/4.5/library/tensorflow'
       * Exists in conda env: TRUE
       
       -- TensorFlow Probability ------------------------------------------------------

--- a/tests/testthat/_snaps/transforms.md
+++ b/tests/testthat/_snaps/transforms.md
@@ -4,6 +4,6 @@
       imultilogit(x)
     Condition
       Error in `imultilogit()`:
-      ! `x must be two dimensional`
+      ! `x` must be two dimensional
       However, `x` has dimensions: 3x4x3
 


### PR DESCRIPTION
Resolves #535 

``` r
devtools::load_all(".")
#> ℹ Loading greta
#> ℹ Initialising python and checking dependencies, this may take a moment.
#> 
#> ✔ Initialising python and checking dependencies ... done!
check_1d(c(1))
#> Error:
#> ! `c(1)` must be two dimensional
#> However, `c(1)` is one dimensional and contains the value: 1
check_2d(c(1))
#> Error:
#> ! `c(1)` must be two dimensional
#> However, `c(1)` has dimensions:
check_2d_multivariate(c(1))
#> Error in `check_2d_multivariate()`:
#> ! `x` must be two dimensional
#> However, `x` is one dimensional and contains the value: 1
```

<sup>Created on 2025-04-30 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.0 (2025-04-11)
#>  os       macOS Sonoma 14.5
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Australia/Hobart
#>  date     2025-04-30
#>  pandoc   3.4 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.6.36 @ /Applications/quarto/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  ! package     * version    date (UTC) lib source
#>    abind         1.4-8      2024-09-12 [1] CRAN (R 4.5.0)
#>    base64enc     0.1-3      2015-07-28 [1] CRAN (R 4.5.0)
#>    brio          1.1.5      2024-04-24 [1] CRAN (R 4.5.0)
#>    cachem        1.1.0      2024-05-16 [1] CRAN (R 4.5.0)
#>    callr         3.7.6      2024-03-25 [1] CRAN (R 4.5.0)
#>    cli           3.6.5      2025-04-23 [1] CRAN (R 4.5.0)
#>    coda          0.19-4.1   2024-01-31 [1] CRAN (R 4.5.0)
#>    codetools     0.2-20     2024-03-31 [2] CRAN (R 4.5.0)
#>    crayon        1.5.3      2024-06-20 [1] CRAN (R 4.5.0)
#>    desc          1.4.3      2023-12-10 [1] CRAN (R 4.5.0)
#>    devtools      2.4.5      2022-10-11 [1] CRAN (R 4.5.0)
#>    digest        0.6.37     2024-08-19 [1] CRAN (R 4.5.0)
#>    ellipsis      0.3.2      2021-04-29 [1] CRAN (R 4.5.0)
#>    evaluate      1.0.3      2025-01-10 [1] CRAN (R 4.5.0)
#>    fastmap       1.2.0      2024-05-15 [1] CRAN (R 4.5.0)
#>    fs            1.6.6      2025-04-12 [1] CRAN (R 4.5.0)
#>    future        1.40.0     2025-04-10 [1] CRAN (R 4.5.0)
#>    globals       0.17.0     2025-04-16 [1] CRAN (R 4.5.0)
#>    glue          1.8.0      2024-09-30 [1] CRAN (R 4.5.0)
#>  P greta       * 0.5.0.9000 2025-04-24 [?] load_all()
#>    hms           1.1.3      2023-03-21 [1] CRAN (R 4.5.0)
#>    htmltools     0.5.8.1    2024-04-04 [1] CRAN (R 4.5.0)
#>    htmlwidgets   1.6.4      2023-12-06 [1] CRAN (R 4.5.0)
#>    httpuv        1.6.16     2025-04-16 [1] CRAN (R 4.5.0)
#>    jsonlite      2.0.0      2025-03-27 [1] CRAN (R 4.5.0)
#>    knitr         1.50       2025-03-16 [1] CRAN (R 4.5.0)
#>    later         1.4.2      2025-04-08 [1] CRAN (R 4.5.0)
#>    lattice       0.22-6     2024-03-20 [2] CRAN (R 4.5.0)
#>    lifecycle     1.0.4      2023-11-07 [1] CRAN (R 4.5.0)
#>    listenv       0.9.1      2024-01-29 [1] CRAN (R 4.5.0)
#>    magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.5.0)
#>    Matrix        1.7-3      2025-03-11 [2] CRAN (R 4.5.0)
#>    memoise       2.0.1      2021-11-26 [1] CRAN (R 4.5.0)
#>    mime          0.13       2025-03-17 [1] CRAN (R 4.5.0)
#>    miniUI        0.1.1.1    2018-05-18 [1] CRAN (R 4.5.0)
#>    parallelly    1.43.0     2025-03-24 [1] CRAN (R 4.5.0)
#>    pillar        1.10.2     2025-04-05 [1] CRAN (R 4.5.0)
#>    pkgbuild      1.4.7      2025-03-24 [1] CRAN (R 4.5.0)
#>    pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.5.0)
#>    pkgload       1.4.0      2024-06-28 [1] CRAN (R 4.5.0)
#>    png           0.1-8      2022-11-29 [1] CRAN (R 4.5.0)
#>    prettyunits   1.2.0      2023-09-24 [1] CRAN (R 4.5.0)
#>    processx      3.8.6      2025-02-21 [1] CRAN (R 4.5.0)
#>    profvis       0.4.0      2024-09-20 [1] CRAN (R 4.5.0)
#>    progress      1.2.3      2023-12-06 [1] CRAN (R 4.5.0)
#>    promises      1.3.2      2024-11-28 [1] CRAN (R 4.5.0)
#>    ps            1.9.1      2025-04-12 [1] CRAN (R 4.5.0)
#>    purrr         1.0.4      2025-02-05 [1] CRAN (R 4.5.0)
#>    R6            2.6.1      2025-02-15 [1] CRAN (R 4.5.0)
#>    Rcpp          1.0.14     2025-01-12 [1] CRAN (R 4.5.0)
#>    remotes       2.5.0      2024-03-17 [1] CRAN (R 4.5.0)
#>    reprex        2.1.1      2024-07-06 [1] CRAN (R 4.5.0)
#>    reticulate    1.42.0     2025-03-25 [1] CRAN (R 4.5.0)
#>    rlang         1.1.6      2025-04-11 [1] CRAN (R 4.5.0)
#>    rmarkdown     2.29       2024-11-04 [1] CRAN (R 4.5.0)
#>    rprojroot     2.0.4      2023-11-05 [1] CRAN (R 4.5.0)
#>    rstudioapi    0.17.1     2024-10-22 [1] CRAN (R 4.5.0)
#>    sessioninfo   1.2.3      2025-02-05 [1] CRAN (R 4.5.0)
#>    shiny         1.10.0     2024-12-14 [1] CRAN (R 4.5.0)
#>    tensorflow    2.16.0     2024-04-15 [1] CRAN (R 4.5.0)
#>    testthat    * 3.2.3      2025-01-13 [1] CRAN (R 4.5.0)
#>    tfruns        1.5.3      2024-04-19 [1] CRAN (R 4.5.0)
#>    urlchecker    1.0.1      2021-11-30 [1] CRAN (R 4.5.0)
#>    usethis       3.1.0      2024-11-26 [1] CRAN (R 4.5.0)
#>    vctrs         0.6.5      2023-12-01 [1] CRAN (R 4.5.0)
#>    whisker       0.4.1      2022-12-05 [1] CRAN (R 4.5.0)
#>    withr         3.0.2      2024-10-28 [1] CRAN (R 4.5.0)
#>    xfun          0.52       2025-04-02 [1] CRAN (R 4.5.0)
#>    xtable        1.8-4      2019-04-21 [1] CRAN (R 4.5.0)
#>    yaml          2.3.10     2024-07-26 [1] CRAN (R 4.5.0)
#>    yesno         0.1.3      2024-07-26 [1] CRAN (R 4.5.0)
#> 
#>  [1] /Users/nick_1/Library/R/arm64/4.5/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library
#> 
#>  * ── Packages attached to the search path.
#>  P ── Loaded and on-disk path mismatch.
#> 
#> ─ Python configuration ───────────────────────────────────────────────────────
#>  python:         /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/bin/python
#>  libpython:      /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/libpython3.10.dylib
#>  pythonhome:     /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2:/Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2
#>  version:        3.10.14 | packaged by conda-forge | (main, Mar 20 2024, 12:51:49) [Clang 16.0.6 ]
#>  numpy:          /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/python3.10/site-packages/numpy
#>  numpy_version:  1.26.4
#>  tensorflow:     /Users/nick/Library/r-miniconda-arm64/envs/greta-env-tf2/lib/python3.10/site-packages/tensorflow
#>  
#>  NOTE: Python version was forced by use_python() function
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>