### PR TITLE
Use `.batch_size` instead of `batch_size` internally

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - `log.greta_array()` function warns if user uses the `base` arg, as it was unused, (#597).
 - Add warmup information to MCMC print method (#652, resolved by #755).
 - Add more options to level of detail in `greta_sitrep()` with "verbosity" argument. There are three levels, "minimal" (default), "detailed", and "quiet". (#612, resolved by #679).
+- Use `.batch_size` instead of `batch_size` internally, to avoid rare name clash errors (#634).
 
 # greta 0.5.0
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -457,12 +457,12 @@ calculate_target_tensor_list <- function(
   tfe <- dag$tf_environment
 
   # add the batch size to the data list and the greta stash (for sub-dags)
-  batch_size <- ifelse(stochastic, as.integer(nsim), 1L)
-  assign("batch_size", batch_size, envir = tfe)
-  assign("batch_size", batch_size, envir = greta_stash)
+  .batch_size <- ifelse(stochastic, as.integer(nsim), 1L)
+  assign(".batch_size", .batch_size, envir = tfe)
+  assign(".batch_size", .batch_size, envir = greta_stash)
 
   values <- lapply(values, add_first_dim)
-  values <- lapply(values, tile_first_dim, batch_size)
+  values <- lapply(values, tile_first_dim, .batch_size)
 
   mapply(
     FUN = assign,

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -212,23 +212,27 @@ dag_class <- R6Class(
     },
     define_batch_size = function() {
       # TF1/2 check?
-      # pretty sure `batch_size` just now needs to be the input of a function
-      # I'm not even sure that batch_size needs to be a function, it might
+      # pretty sure `.batch_size` just now needs to be the input of a function
+      # I'm not even sure that .batch_size needs to be a function, it might
       # just need to be the input to wherever it is used next?
 
       ## NOTE: when calling `model` there is no `free_state` in `tf_environment`
       ## Trying out something where the free state is set if there isn't one?
 
-      if (!exists("batch_size", envir = self$tf_environment)) {
+      if (!exists(".batch_size", envir = self$tf_environment)) {
         with(
           data = self$tf_environment,
-          batch_size <- tf$shape(self$tf_environment$free_state)[0]
+          .batch_size <- tf$shape(self$tf_environment$free_state)[0]
         )
       }
 
       # put this in the greta stash, so it can be accessed by other (sub-)dags
       # if needed, e.g. when using as_tf_function()
-      assign("batch_size", self$tf_environment$batch_size, envir = greta_stash)
+      assign(
+        ".batch_size",
+        self$tf_environment$.batch_size,
+        envir = greta_stash
+      )
     },
 
     define_free_state = function(

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -61,7 +61,7 @@ data_node <- R6Class(
         }
 
         # expand up to batch size - so we can run multiple chains
-        tiling <- c(tfe$batch_size, rep(1L, ndim))
+        tiling <- c(tfe$.batch_size, rep(1L, ndim))
         batched_tensor <- tf$tile(unbatched_tensor, tiling)
 
         # put unbatched tensor in environment so it can be set

--- a/R/sampler_class.R
+++ b/R/sampler_class.R
@@ -534,7 +534,7 @@ sampler <- R6Class(
       # combine the sampler information with information on the sampler's tuning
       # parameters, and make into a dict
 
-      dag$set_tf_data_list("batch_size", nrow(self$free_state))
+      dag$set_tf_data_list(".batch_size", nrow(self$free_state))
 
       # run the sampler, handling numerical errors
       batch_results <- self$sample_carefully(

--- a/R/tf_functions.R
+++ b/R/tf_functions.R
@@ -415,8 +415,8 @@ tf_icauchit <- function(x) {
 }
 
 tf_imultilogit <- function(x) {
-  batch_size <- tf$shape(x)[[0]]
-  shape <- c(batch_size, dim(x)[[2]], 1L)
+  .batch_size <- tf$shape(x)[[0]]
+  shape <- c(.batch_size, dim(x)[[2]], 1L)
   zeros <- tf$zeros(shape, tf_float())
   latent <- tf$concat(list(x, zeros), 2L)
   tf$nn$softmax(latent)
@@ -436,8 +436,8 @@ tf_extract <- function(x, nelem, index, dims_out) {
 
   # reshape, handling unknown dimensions even when the output has 0-dimension
   # (which prevents us from just using -1 on the first dimension)
-  batch_size <- tf$shape(x)[[0]]
-  shape_list <- c(list(batch_size), as.integer(to_shape(dims_out)))
+  .batch_size <- tf$shape(x)[[0]]
+  shape_list <- c(list(.batch_size), as.integer(to_shape(dims_out)))
   shape_out <- tf$stack(shape_list)
   tensor_out <- tf$reshape(tensor_out_flat, shape_out)
   tensor_out
@@ -705,7 +705,7 @@ tf_ordered_bijector <- function(dim) {
 # including the batch dimension
 tf_randu <- function(dim, dag) {
   uniform <- tfp$distributions$Uniform(low = fl(0), high = fl(1))
-  shape <- c(dag$tf_environment$batch_size, as.list(dim))
+  shape <- c(dag$tf_environment$.batch_size, as.list(dim))
   uniform$sample(sample_shape = shape, seed = get_seed())
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,7 +50,7 @@ fl <- function(x) {
 # get the tensor for the batch size in the dag recently defined (since it's
 # not always possible to pass the dag in)
 get_batch_size <- function() {
-  greta_stash$batch_size
+  greta_stash$.batch_size
 }
 
 # coerce an integer(ish) vector to a list as expected in tensorflow shape
@@ -185,9 +185,9 @@ drop_column_dim <- function(x) {
 # dimension, tile x to have first dimension matching y (dimension determined at
 # run time)
 expand_to_batch <- function(x, y) {
-  batch_size <- tf$shape(y)[[0]]
+  .batch_size <- tf$shape(y)[[0]]
   ndim <- n_dim(x)
-  tf$tile(x, c(batch_size, rep(1L, ndim - 1)))
+  tf$tile(x, c(.batch_size, rep(1L, ndim - 1)))
 }
 
 # does this tensor have a batch dimension (of unknown size) as its first
@@ -673,7 +673,7 @@ as_tf_function <- function(r_fun, ...) {
     #  - how many chains or whatever to use
     # get the batch size from the input tensors - it should be written to the
     # stash by the main dag - but only if a main dag is defined. What about in calculate?
-    sub_tfe$batch_size <- get_batch_size()
+    sub_tfe$.batch_size <- get_batch_size()
 
     # set the input tensors as the values for the dummy greta arrays in the new
     # tf_environment

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -22,7 +22,7 @@ grab <- function(x, dag = NULL) {
     dag <- dag_class$new(list(x))
   }
 
-  dag$tf_environment$batch_size <- 1L
+  dag$tf_environment$.batch_size <- 1L
   node$define_tf(dag)
   x_name <- dag$tf_name(node)
   out <- dag$tf_environment[[x_name]]
@@ -128,7 +128,7 @@ greta_density <- function(
   # create dag
   dag <- dag_class$new(list(x_))
 
-  dag$tf_environment$batch_size <- 1L
+  dag$tf_environment$.batch_size <- 1L
   distrib_node$define_tf(dag)
 
   # get the log density as a vector

--- a/tests/testthat/test-tensorflow-rpkg-stability.R
+++ b/tests/testthat/test-tensorflow-rpkg-stability.R
@@ -125,8 +125,8 @@ test_that("[, [[, and assignment returns right object", {
 })
 
 # other parts to test:
-# batch_size <- tf$shape(x)[[0]]
-# shape_list <- c(list(batch_size), as.integer(to_shape(dims_out)))
+# .batch_size <- tf$shape(x)[[0]]
+# shape_list <- c(list(.batch_size), as.integer(to_shape(dims_out)))
 # shape_out <- tf$stack(shape_list)
 #
 # tf$reshape(ref[, idx, ], tensorflow::as_tensor(shape(-1, length(idx), 1)))


### PR DESCRIPTION
to avoid rare name clash errors. Resolves #634