### PR TITLE
Note that docs/ is gitignored and CI-built in website guide

### DIFF
--- a/.EDIT_WEBSITE.md
+++ b/.EDIT_WEBSITE.md
@@ -36,6 +36,10 @@ pkgdown::build_site()
 `pkgdown::preview_site()` serves an already-built `docs/` in your browser; it
 does not build anything itself.
 
+`docs/` is generated output — it is gitignored and rebuilt from scratch by CI
+on every deployment, so you never need to commit it (and shouldn't). Build it
+locally only to preview your changes.
+
 For a quick look at just the chrome (navbar, theme, reference index) without
 rendering articles:
 
@@ -205,7 +209,8 @@ Pushing to `main` triggers `.github/workflows/pkgdown.yaml`, which builds the
 site and deploys it to the `gh-pages` branch. This assumes the expensive
 vignettes are pre-computed (so the runner never needs TensorFlow). If you change
 an expensive vignette, remember to run `precompute.R` and commit the generated
-files, or the deployed site will be stale.
+files, or the deployed site will be stale. The deployed `docs/` content is
+produced entirely by CI and is not tracked in the repository.
 
 ## Common pitfalls
 


### PR DESCRIPTION
Following #813, which untracks and gitignores \`docs/\`, this documents in
\`.EDIT_WEBSITE.md\` that \`docs/\` is generated output rebuilt by CI on every
deployment, so contributors don't re-commit it.