### PR TITLE
Cap TF thread pools at 2 under R CMD check (#796)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * When the number of cores requested exceeds the number of cores detected, then the number of cores detected will be used.
 * Ensure `n_cores` arg defaults to 2 cores, and `chains` defaults to 2 chains.
 * Cap TensorFlow's internal CPU threadpool inside vignette builds (via `TF_NUM_INTRAOP_THREADS` and `TF_NUM_INTEROP_THREADS`) so CRAN's CPU/elapsed timing on vignette rebuild stays under the two-core limit (#796).
+* greta now also caps TensorFlow's CPU thread pools at 2 when running under `R CMD check` (detected via the `_R_CHECK_LIMIT_CORES_` environment variable), so checks on CRAN machines respect the two-core limit (#796).
 
 ### Installation and dependencies
 

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -42,6 +42,8 @@ check_tf_version <- function(
     )
     cat("\n")
     greta_stash$python_has_been_initialised <- TRUE
+    # cap TF's thread pools if running under R CMD check (#796)
+    limit_tf_cores_under_check()
   }
 
   if (!all(requirements_valid)) {
@@ -74,6 +76,33 @@ check_tf_version <- function(
   invisible(all(requirements_valid))
 }
 
+# CRAN enforces a two-core limit on package checks, and TensorFlow otherwise
+# uses all available cores by default, which can trip the "CPU time X times
+# elapsed time" check (#796). R CMD check signals this limit via the
+# _R_CHECK_LIMIT_CORES_ environment variable, so we cap TF's thread pools
+# when it is set. The call is wrapped in tryCatch because TensorFlow errors
+# if its thread pools are changed after its context has already initialised;
+# in that case we silently leave the pools alone. The threading argument
+# defaults to the delay-loaded tf module's threading config, but is
+# injectable so this can be unit tested without touching TensorFlow.
+limit_tf_cores_under_check <- function(threading = tf$config$threading) {
+  check_cores_env <- Sys.getenv("_R_CHECK_LIMIT_CORES_")
+
+  if (identical(check_cores_env, "") || tolower(check_cores_env) == "false") {
+    return(invisible(FALSE))
+  }
+
+  capped <- tryCatch(
+    {
+      threading$set_intra_op_parallelism_threads(2L)
+      threading$set_inter_op_parallelism_threads(2L)
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+
+  invisible(capped)
+}
 
 # check dimensions of arguments to ops, and return the maximum dimension
 check_dims <- function(..., target_dim = NULL, call = rlang::caller_env()) {

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -1,0 +1,41 @@
+test_that("limit_tf_cores_under_check caps TF thread pools under R CMD check", {
+  withr::local_envvar("_R_CHECK_LIMIT_CORES_" = "TRUE")
+  intra <- NULL
+  inter <- NULL
+  fake_threading <- list(
+    set_intra_op_parallelism_threads = \(n) intra <<- n,
+    set_inter_op_parallelism_threads = \(n) inter <<- n
+  )
+
+  expect_true(limit_tf_cores_under_check(threading = fake_threading))
+  expect_equal(intra, 2L)
+  expect_equal(inter, 2L)
+})
+
+test_that("limit_tf_cores_under_check does nothing when not under R CMD check", {
+  called <- FALSE
+  fake_threading <- list(
+    set_intra_op_parallelism_threads = \(n) called <<- TRUE,
+    set_inter_op_parallelism_threads = \(n) called <<- TRUE
+  )
+
+  withr::local_envvar("_R_CHECK_LIMIT_CORES_" = NA)
+  expect_false(limit_tf_cores_under_check(threading = fake_threading))
+  expect_false(called)
+
+  withr::local_envvar("_R_CHECK_LIMIT_CORES_" = "false")
+  expect_false(limit_tf_cores_under_check(threading = fake_threading))
+  expect_false(called)
+})
+
+test_that("limit_tf_cores_under_check survives TensorFlow errors", {
+  withr::local_envvar("_R_CHECK_LIMIT_CORES_" = "TRUE")
+  fake_threading <- list(
+    set_intra_op_parallelism_threads = \(n) {
+      stop("cannot modify after context init")
+    },
+    set_inter_op_parallelism_threads = \(n) NULL
+  )
+
+  expect_false(limit_tf_cores_under_check(threading = fake_threading))
+})


### PR DESCRIPTION
Belt-and-braces for CRAN's two-core limit (#796): when `_R_CHECK_LIMIT_CORES_` is set (as on CRAN check machines), the new internal `limit_tf_cores_under_check()` caps TensorFlow's intra- and inter-op parallelism at 2 threads — called once in `check_tf_version()`, right after Python first initialises.

- `tryCatch`-guarded: TF rejects thread-pool changes after its context has initialised; in that case the pools are left alone
- No-op in normal sessions (env var unset) and when the limit is explicitly disabled (`"false"`)
- `threading` argument is injectable, giving three pure unit tests in `tests/testthat/test-checkers.R` that need no TensorFlow
- NEWS bullet added alongside the existing vignette-threadpool cap

Vignette precomputation already resolved the original CRAN rejection ("CPU time 3.8 times elapsed time"); this cap protects examples/tests and future-proofs the check itself. Final code step before the CRAN 0.6.0 resubmission (#805).
